### PR TITLE
Milestone 3: Implement restore mode with remote download workers

### DIFF
--- a/cmd/media-offload/main.go
+++ b/cmd/media-offload/main.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/download"
+	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
 	"github.com/mmilitzer/xvid-media-offload/pkg/shrink"
 )
@@ -21,6 +23,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Commands:")
 		fmt.Fprintln(os.Stderr, "  scan    Scan for offload candidates")
 		fmt.Fprintln(os.Stderr, "  shrink  Offload eligible files by punching holes")
+		fmt.Fprintln(os.Stderr, "  restore Restore offloaded files from remote storage")
 		os.Exit(1)
 	}
 
@@ -30,6 +33,8 @@ func main() {
 		os.Exit(runScan(os.Args[2:]))
 	case "shrink":
 		os.Exit(runShrink(os.Args[2:]))
+	case "restore":
+		os.Exit(runRestore(os.Args[2:]))
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
 		os.Exit(1)
@@ -287,5 +292,96 @@ func printShrinkReport(res *shrink.Result, dryRun bool, verbose bool) {
 	} else if !dryRun && len(res.Offloaded) == 0 {
 		fmt.Println()
 		fmt.Println("No files were offloaded.")
+	}
+}
+
+func runRestore(args []string) int {
+	fs := flag.NewFlagSet("restore", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file (required)")
+	dryRun := fs.Bool("dry-run", false, "Report candidates without downloading or modifying files")
+	verbose := fs.Bool("verbose", false, "Enable verbose output with per-file skip and error details")
+	workers := fs.Int("workers", 4, "Number of parallel restore workers")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %v\n", err)
+		return 1
+	}
+
+	if *configPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: --config is required")
+		return 1
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		return 1
+	}
+	cfg.Verbose = *verbose
+
+	var database *db.DB
+	if cfg.DatabasePath != "" {
+		database, err = db.Open(cfg.DatabasePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening database: %v\n", err)
+			return 1
+		}
+		defer database.Close()
+	}
+
+	downloader := &download.HTTPDownloader{}
+	res, err := restore.Run(cfg, *dryRun, *workers, database, downloader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error restoring: %v\n", err)
+		return 1
+	}
+
+	printRestoreReport(res, *dryRun, *verbose)
+	return 0
+}
+
+func printRestoreReport(res *restore.Result, dryRun bool, verbose bool) {
+	if dryRun {
+		fmt.Println("=== Dry-Run Restore Report ===")
+	} else {
+		fmt.Println("=== Restore Report ===")
+	}
+	fmt.Println()
+
+	fmt.Printf("restore candidates found: %d\n", res.Candidates)
+	fmt.Printf("jobs queued:              %d\n", res.Queued)
+	if !dryRun {
+		fmt.Printf("restored successfully:    %d\n", len(res.Restored))
+		fmt.Printf("failed:                   %d\n", res.Failed)
+	}
+	fmt.Printf("skipped no remote id:     %d\n", res.SkippedNoRemoteID)
+	if !dryRun {
+		fmt.Printf("skipped no credentials:   %d\n", res.SkippedNoCreds)
+		fmt.Printf("skipped no disk space:    %d\n", res.SkippedNoSpace)
+	}
+	fmt.Printf("errors:                   %d\n", res.Errors)
+	fmt.Println()
+
+	if !dryRun && len(res.Restored) > 0 {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "PATH\tREMOTE ID\tAUTOGRAPH\tSIZE\tMARKER")
+		for _, r := range res.Restored {
+			fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\n",
+				r.Path,
+				r.RemoteID,
+				r.Autograph,
+				r.Size,
+				r.MarkerPath,
+			)
+		}
+		w.Flush()
+		fmt.Println()
+	}
+
+	if verbose && len(res.ErrorDetails) > 0 {
+		fmt.Println("=== Errors ===")
+		for _, e := range res.ErrorDetails {
+			fmt.Println(e)
+		}
+		fmt.Println()
 	}
 }

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -72,6 +72,7 @@ func Parse(path string) (*Credentials, error) {
 		}
 
 		if inXvidSection {
+			line = stripInlineComment(line)
 			key, val, ok := parseINIKeyValue(line)
 			if !ok {
 				continue
@@ -94,6 +95,20 @@ func Parse(path string) (*Credentials, error) {
 	}
 
 	return &creds, nil
+}
+
+func stripInlineComment(line string) string {
+	inQuotes := false
+	for i, r := range line {
+		if r == '"' || r == '\'' {
+			inQuotes = !inQuotes
+			continue
+		}
+		if !inQuotes && (r == ';' || r == '#') {
+			return line[:i]
+		}
+	}
+	return line
 }
 
 func parseINIKeyValue(line string) (key, val string, ok bool) {

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,0 +1,108 @@
+package credentials
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const credentialFilename = "cmsinclude.ini.php"
+
+// Credentials holds HMAC signing credentials for a scan root.
+type Credentials struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// FindForPath walks upward from the given path through parent directories
+// and returns the credentials from the first found credential file.
+func FindForPath(startPath string) (*Credentials, string, error) {
+	dir := filepath.Clean(startPath)
+	if info, err := os.Stat(dir); err == nil && !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+
+	for {
+		credPath := filepath.Join(dir, credentialFilename)
+		if info, err := os.Stat(credPath); err == nil && !info.IsDir() {
+			creds, err := Parse(credPath)
+			if err != nil {
+				return nil, credPath, fmt.Errorf("parsing %s: %w", credPath, err)
+			}
+			return creds, credPath, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return nil, "", fmt.Errorf("no %s found in any parent of %s", credentialFilename, startPath)
+}
+
+// Parse reads credentials from a PHP INI-style file.
+func Parse(path string) (*Credentials, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening credential file: %w", err)
+	}
+	defer f.Close()
+
+	var creds Credentials
+	inXvidSection := false
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if line == "[xvid]" {
+			inXvidSection = true
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inXvidSection = false
+			continue
+		}
+
+		if inXvidSection {
+			key, val, ok := parseINIKeyValue(line)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "APP_CLIENT_ID":
+				creds.ClientID = val
+			case "APP_CLIENT_SECRET":
+				creds.ClientSecret = val
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading credential file: %w", err)
+	}
+
+	if creds.ClientID == "" || creds.ClientSecret == "" {
+		return nil, fmt.Errorf("missing APP_CLIENT_ID or APP_CLIENT_SECRET in %s", path)
+	}
+
+	return &creds, nil
+}
+
+func parseINIKeyValue(line string) (key, val string, ok bool) {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	key = strings.TrimSpace(parts[0])
+	val = strings.TrimSpace(parts[1])
+	val = strings.Trim(val, `"'`)
+	return key, val, true
+}

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -44,6 +44,72 @@ APP_CLIENT_SECRET = "secret"
 	}
 }
 
+func TestParseWithInlineCommentQuoted(t *testing.T) {
+	content := `[xvid]
+APP_CLIENT_ID = "test-id-123"     ;<--- Put your application Client ID here
+APP_CLIENT_SECRET = "dGVzdC1zZWNyZXQ=" ;<--- Put your application Client Secret here
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := Parse(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.ClientID != "test-id-123" {
+		t.Errorf("unexpected client id: %s", creds.ClientID)
+	}
+	if creds.ClientSecret != "dGVzdC1zZWNyZXQ=" {
+		t.Errorf("unexpected client secret: %s", creds.ClientSecret)
+	}
+}
+
+func TestParseWithInlineCommentUnquoted(t *testing.T) {
+	content := `[xvid]
+APP_CLIENT_ID = test-id-123 ; comment
+APP_CLIENT_SECRET = dGVzdC1zZWNyZXQ= ; comment
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := Parse(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.ClientID != "test-id-123" {
+		t.Errorf("unexpected client id: %s", creds.ClientID)
+	}
+	if creds.ClientSecret != "dGVzdC1zZWNyZXQ=" {
+		t.Errorf("unexpected client secret: %s", creds.ClientSecret)
+	}
+}
+
+func TestParseSemicolonInsideQuotes(t *testing.T) {
+	content := `[xvid]
+APP_CLIENT_ID = "te;st-id"
+APP_CLIENT_SECRET = "dGVzd;C1zZWNyZXQ="
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := Parse(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.ClientID != "te;st-id" {
+		t.Errorf("unexpected client id: %s", creds.ClientID)
+	}
+	if creds.ClientSecret != "dGVzd;C1zZWNyZXQ=" {
+		t.Errorf("unexpected client secret: %s", creds.ClientSecret)
+	}
+}
+
 func TestParseMissingCredentials(t *testing.T) {
 	content := `[xvid]
 APP_CLIENT_ID = "test-id"

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,0 +1,100 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseValidINI(t *testing.T) {
+	content := `[xvid]
+APP_CLIENT_ID = "test-id-123"
+APP_CLIENT_SECRET = "dGVzdC1zZWNyZXQ="
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := Parse(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.ClientID != "test-id-123" {
+		t.Errorf("unexpected client id: %s", creds.ClientID)
+	}
+	if creds.ClientSecret != "dGVzdC1zZWNyZXQ=" {
+		t.Errorf("unexpected client secret: %s", creds.ClientSecret)
+	}
+}
+
+func TestParseMissingSection(t *testing.T) {
+	content := `[other]
+APP_CLIENT_ID = "test-id"
+APP_CLIENT_SECRET = "secret"
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(path)
+	if err == nil {
+		t.Error("expected error for missing [xvid] section")
+	}
+}
+
+func TestParseMissingCredentials(t *testing.T) {
+	content := `[xvid]
+APP_CLIENT_ID = "test-id"
+`
+	path := filepath.Join(t.TempDir(), "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(path)
+	if err == nil {
+		t.Error("expected error for missing client secret")
+	}
+}
+
+func TestFindForPathWalkUp(t *testing.T) {
+	tmpDir := t.TempDir()
+	content := `[xvid]
+APP_CLIENT_ID = "found-id"
+APP_CLIENT_SECRET = "found-secret"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, credentialFilename), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	subDir := filepath.Join(tmpDir, "content", "group1", "set1")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, foundPath, err := FindForPath(subDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.ClientID != "found-id" {
+		t.Errorf("unexpected client id: %s", creds.ClientID)
+	}
+	if foundPath != filepath.Join(tmpDir, credentialFilename) {
+		t.Errorf("unexpected path: %s", foundPath)
+	}
+}
+
+func TestFindForPathNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "content", "group1")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := FindForPath(subDir)
+	if err == nil {
+		t.Error("expected error when credential file not found")
+	}
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -56,6 +56,30 @@ func (db *DB) UpsertOffloadedFile(localPath, remoteFileID string, autograph int,
 	return err
 }
 
+// GetOffloadedFile retrieves a record by local path.
+func (db *DB) GetOffloadedFile(localPath string) (remoteFileID string, autograph int, originalSize int64, offloadedAt time.Time, err error) {
+	row := db.conn.QueryRow(`
+		SELECT remote_file_id, autograph, original_size, offloaded_at_unix
+		FROM offloaded_files
+		WHERE local_path = ?
+	`, localPath)
+	var offloadedAtUnix int64
+	err = row.Scan(&remoteFileID, &autograph, &originalSize, &offloadedAtUnix)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", 0, 0, time.Time{}, fmt.Errorf("not found")
+		}
+		return "", 0, 0, time.Time{}, err
+	}
+	return remoteFileID, autograph, originalSize, time.Unix(offloadedAtUnix, 0), nil
+}
+
+// DeleteOffloadedFile removes a record by local path.
+func (db *DB) DeleteOffloadedFile(localPath string) error {
+	_, err := db.conn.Exec(`DELETE FROM offloaded_files WHERE local_path = ?`, localPath)
+	return err
+}
+
 // Close closes the database connection.
 func (db *DB) Close() error {
 	return db.conn.Close()

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -83,7 +83,7 @@ func (s *Signer) SignURL(fileID string, autograph bool) (string, error) {
 	expires := time.Now().Add(defaultExpiry).Unix()
 	url += "&client_id=" + s.ClientID + "&expiry_time=" + strconv.FormatInt(expires, 10)
 
-	key, err := base64.StdEncoding.DecodeString(s.ClientSecret)
+	key, err := decodeClientSecret(s.ClientSecret)
 	if err != nil {
 		return "", fmt.Errorf("decoding client_secret: %w", err)
 	}
@@ -94,4 +94,19 @@ func (s *Signer) SignURL(fileID string, autograph bool) (string, error) {
 
 	signedURL := apiBaseURL + url + "&signature=" + signature
 	return signedURL, nil
+}
+
+// decodeClientSecret attempts to decode a base64-encoded client secret,
+// accepting standard, URL-safe, and unpadded variants.
+func decodeClientSecret(s string) ([]byte, error) {
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	if b, err := base64.URLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	if b, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	return nil, fmt.Errorf("unable to decode client_secret as base64")
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,0 +1,97 @@
+package download
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	apiBaseURL     = "https://api.xvid.com"
+	signPath       = "/v1/files/downloads/"
+	defaultExpiry  = 30 * time.Minute
+)
+
+// Downloader is the interface for downloading files. It can be mocked in tests.
+type Downloader interface {
+	Download(signedURL string, destPath string) error
+}
+
+// HTTPDownloader implements Downloader using the standard HTTP client.
+type HTTPDownloader struct {
+	Client *http.Client
+}
+
+// Download downloads the resource at signedURL to destPath.
+func (d *HTTPDownloader) Download(signedURL string, destPath string) error {
+	client := d.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Get(signedURL)
+	if err != nil {
+		return fmt.Errorf("http GET: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("creating dest file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("writing dest file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("fsync dest file: %w", err)
+	}
+
+	return nil
+}
+
+// Signer generates HMAC-signed temporary download URLs.
+type Signer struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// SignURL creates a signed download URL for the given fileID.
+// If autograph is true, it adds expert_mode=true to the query.
+func (s *Signer) SignURL(fileID string, autograph bool) (string, error) {
+	if s.ClientID == "" || s.ClientSecret == "" {
+		return "", fmt.Errorf("client_id and client_secret are required")
+	}
+
+	url := signPath + "?file_id=" + fileID + "&redirect=true"
+	if autograph {
+		url += "&expert_mode=true"
+	}
+
+	expires := time.Now().Add(defaultExpiry).Unix()
+	url += "&client_id=" + s.ClientID + "&expiry_time=" + strconv.FormatInt(expires, 10)
+
+	key, err := base64.StdEncoding.DecodeString(s.ClientSecret)
+	if err != nil {
+		return "", fmt.Errorf("decoding client_secret: %w", err)
+	}
+
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(url))
+	signature := fmt.Sprintf("%x", h.Sum(nil))
+
+	signedURL := apiBaseURL + url + "&signature=" + signature
+	return signedURL, nil
+}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -1,0 +1,95 @@
+package download
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSignURLBasic(t *testing.T) {
+	signer := &Signer{
+		ClientID:     "test-client-id",
+		ClientSecret: base64.StdEncoding.EncodeToString([]byte("test-secret-key")),
+	}
+
+	signedURL, err := signer.SignURL("file123", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(signedURL, apiBaseURL) {
+		t.Errorf("expected prefix %s, got %s", apiBaseURL, signedURL)
+	}
+	if !strings.Contains(signedURL, "file_id=file123") {
+		t.Error("expected file_id parameter")
+	}
+	if !strings.Contains(signedURL, "client_id=test-client-id") {
+		t.Error("expected client_id parameter")
+	}
+	if strings.Contains(signedURL, "expert_mode") {
+		t.Error("did not expect expert_mode when autograph is false")
+	}
+	if !strings.Contains(signedURL, "signature=") {
+		t.Error("expected signature parameter")
+	}
+}
+
+func TestSignURLWithExpertMode(t *testing.T) {
+	signer := &Signer{
+		ClientID:     "test-client-id",
+		ClientSecret: base64.StdEncoding.EncodeToString([]byte("test-secret-key")),
+	}
+
+	signedURL, err := signer.SignURL("file123", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(signedURL, "expert_mode=true") {
+		t.Error("expected expert_mode=true when autograph is true")
+	}
+}
+
+func TestSignURLEmptyCredentials(t *testing.T) {
+	signer := &Signer{}
+	_, err := signer.SignURL("file123", false)
+	if err == nil {
+		t.Error("expected error for empty credentials")
+	}
+}
+
+func TestSignURLSignatureValid(t *testing.T) {
+	secret := []byte("my-secret")
+	signer := &Signer{
+		ClientID:     "client42",
+		ClientSecret: base64.StdEncoding.EncodeToString(secret),
+	}
+
+	signedURL, err := signer.SignURL("abc456", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Extract the URL part before signature and the signature itself.
+	parts := strings.SplitN(signedURL, "&signature=", 2)
+	if len(parts) != 2 {
+		t.Fatal("could not split signed URL")
+	}
+	urlPart := strings.TrimPrefix(parts[0], apiBaseURL)
+	expectedSig := parts[1]
+
+	key, err := base64.StdEncoding.DecodeString(signer.ClientSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(urlPart))
+	computedSig := fmt.Sprintf("%x", h.Sum(nil))
+
+	if !hmac.Equal([]byte(expectedSig), []byte(computedSig)) {
+		t.Error("signature mismatch")
+	}
+}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -53,6 +53,25 @@ func TestSignURLWithExpertMode(t *testing.T) {
 	}
 }
 
+func TestSignURLWithURLSafeBase64Secret(t *testing.T) {
+	// URL-safe base64: replaces + with - and / with _, omits padding.
+	raw := []byte("my-secret-key")
+	urlSafeSecret := base64.RawURLEncoding.EncodeToString(raw)
+
+	signer := &Signer{
+		ClientID:     "test-client-id",
+		ClientSecret: urlSafeSecret,
+	}
+
+	signedURL, err := signer.SignURL("file123", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(signedURL, "signature=") {
+		t.Error("expected signature parameter")
+	}
+}
+
 func TestSignURLEmptyCredentials(t *testing.T) {
 	signer := &Signer{}
 	_, err := signer.SignURL("file123", false)

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1,0 +1,271 @@
+package restore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"github.com/mmilitzer/xvid-media-offload/pkg/credentials"
+	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/download"
+	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
+	"golang.org/x/sys/unix"
+)
+
+const offloadedMarkerContent = `This media file is stored on Xvid MediaHub cloud storage.
+The local file is still present for CMS compatibility but it has been truncated with most disk space freed.
+Delete this .offloaded file to initiate restoring the full local copy.
+`
+
+// RestoreInfo holds details about a successfully restored file.
+type RestoreInfo struct {
+	Path       string
+	RemoteID   string
+	Autograph  int
+	Size       int64
+	MarkerPath string
+}
+
+// Result holds the outcome of a restore run.
+type Result struct {
+	Candidates         int
+	Queued             int
+	Restored           []RestoreInfo
+	Failed             int
+	SkippedNoRemoteID  int
+	SkippedNoCreds     int
+	SkippedNoSpace     int
+	Errors             int
+	ErrorDetails       []string
+}
+
+// Job represents a single restore task.
+type Job struct {
+	File scanner.FileInfo
+}
+
+// Run scans for restore candidates and restores them using a worker pool.
+// If dryRun is true, no files are modified or downloaded.
+func Run(cfg *config.Config, dryRun bool, workers int, database *db.DB, downloader download.Downloader) (*Result, error) {
+	if workers <= 0 {
+		workers = 4
+	}
+
+	scanRes, err := scanForRestore(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("scanning for restore: %w", err)
+	}
+
+	res := &Result{
+		Candidates: len(scanRes.Files),
+	}
+
+	// Pre-resolve remote IDs and credentials, build job queue.
+	var jobs []Job
+	for _, f := range scanRes.Files {
+		remoteID := f.RemoteID
+
+		// Fallback to DB if no remote ID from marker.
+		if remoteID == "" && database != nil {
+			dbRemoteID, _, _, _, dbErr := database.GetOffloadedFile(f.Path)
+			if dbErr == nil {
+				remoteID = dbRemoteID
+			}
+		}
+
+		if remoteID == "" {
+			res.SkippedNoRemoteID++
+			msg := fmt.Sprintf("%s: no remote file id (marker or DB)", f.Path)
+			res.ErrorDetails = append(res.ErrorDetails, msg)
+			if cfg.Verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			continue
+		}
+
+		if dryRun {
+			res.Queued++
+			continue
+		}
+
+		// Find credentials for this file's scan root.
+		_, _, credErr := credentials.FindForPath(f.ScanRoot)
+		if credErr != nil {
+			res.SkippedNoCreds++
+			msg := fmt.Sprintf("%s: no credentials found: %v", f.Path, credErr)
+			res.ErrorDetails = append(res.ErrorDetails, msg)
+			if cfg.Verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			continue
+		}
+
+		jobs = append(jobs, Job{
+			File: f,
+		})
+		res.Queued++
+	}
+
+	if dryRun || len(jobs) == 0 {
+		return res, nil
+	}
+
+	// Worker pool.
+	var wg sync.WaitGroup
+	jobCh := make(chan Job, len(jobs))
+	var mu sync.Mutex
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobCh {
+				if err := restoreJob(job, cfg, database, downloader, res, &mu); err != nil {
+					mu.Lock()
+					res.Failed++
+					msg := fmt.Sprintf("%s: restore failed: %v", job.File.Path, err)
+					res.ErrorDetails = append(res.ErrorDetails, msg)
+					if cfg.Verbose {
+						fmt.Fprintln(os.Stderr, msg)
+					}
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+
+	for _, job := range jobs {
+		jobCh <- job
+	}
+	close(jobCh)
+	wg.Wait()
+
+	return res, nil
+}
+
+func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader, res *Result, mu *sync.Mutex) error {
+	f := job.File
+
+	// Resolve remote ID and autograph again inside worker.
+	remoteID := f.RemoteID
+	autograph := f.Autograph
+	if remoteID == "" && database != nil {
+		dbRemoteID, dbAutograph, _, _, dbErr := database.GetOffloadedFile(f.Path)
+		if dbErr == nil {
+			remoteID = dbRemoteID
+			autograph = dbAutograph
+		}
+	}
+	if remoteID == "" {
+		return fmt.Errorf("no remote file id")
+	}
+
+	// Resolve credentials.
+	creds, _, err := credentials.FindForPath(f.ScanRoot)
+	if err != nil {
+		return fmt.Errorf("credentials: %w", err)
+	}
+
+	// Check disk space.
+	enough, avail, err := checkDiskSpace(f.Path, f.Size)
+	if err != nil {
+		return fmt.Errorf("disk space check: %w", err)
+	}
+	if !enough {
+		// Recreate .offloaded marker and skip.
+		err = os.WriteFile(f.Path+".offloaded", []byte(offloadedMarkerContent), 0644)
+		if err != nil {
+			return fmt.Errorf("not enough space (%d bytes available) and failed to recreate marker: %w", avail, err)
+		}
+		mu.Lock()
+		res.SkippedNoSpace++
+		mu.Unlock()
+		return nil
+	}
+
+	// Sign download URL.
+	signer := &download.Signer{
+		ClientID:     creds.ClientID,
+		ClientSecret: creds.ClientSecret,
+	}
+	signedURL, err := signer.SignURL(remoteID, autograph == 1)
+	if err != nil {
+		return fmt.Errorf("signing URL: %w", err)
+	}
+
+	// Download to temp file.
+	tempPath := f.Path + ".restore." + uuid.NewString() + ".tmp"
+	err = downloader.Download(signedURL, tempPath)
+	if err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("download: %w", err)
+	}
+
+	// Verify size if known.
+	if f.Size > 0 {
+		fi, err := os.Stat(tempPath)
+		if err != nil {
+			os.Remove(tempPath)
+			return fmt.Errorf("stat temp file: %w", err)
+		}
+		if fi.Size() != f.Size {
+			os.Remove(tempPath)
+			return fmt.Errorf("size mismatch: expected %d, got %d", f.Size, fi.Size())
+		}
+	}
+
+	// Atomic rename.
+	err = os.Rename(tempPath, f.Path)
+	if err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("atomic rename: %w", err)
+	}
+
+	// Fsync directory.
+	dir := filepath.Dir(f.Path)
+	dirFile, err := os.Open(dir)
+	if err == nil {
+		unix.Fsync(int(dirFile.Fd()))
+		dirFile.Close()
+	}
+
+	// Update mtime to now so it is not immediately offloaded again.
+	now := time.Now()
+	os.Chtimes(f.Path, now, now)
+
+	// Remove DB entry if present.
+	if database != nil {
+		_ = database.DeleteOffloadedFile(f.Path)
+	}
+
+	mu.Lock()
+	res.Restored = append(res.Restored, RestoreInfo{
+		Path:       f.Path,
+		RemoteID:   remoteID,
+		Autograph:  autograph,
+		Size:       f.Size,
+		MarkerPath: f.MarkerPath,
+	})
+	mu.Unlock()
+
+	return nil
+}
+
+var checkDiskSpace = hasEnoughSpace
+
+var scanForRestore = scanner.ScanForRestore
+
+func hasEnoughSpace(path string, needed int64) (bool, int64, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(filepath.Dir(path), &stat)
+	if err != nil {
+		return false, 0, fmt.Errorf("statfs: %w", err)
+	}
+	avail := int64(stat.Bavail) * int64(stat.Bsize)
+	// Require a little headroom beyond the file size itself.
+	return avail > needed+1024*1024, avail, nil
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -45,7 +45,8 @@ type Result struct {
 
 // Job represents a single restore task.
 type Job struct {
-	File scanner.FileInfo
+	File        scanner.FileInfo
+	Credentials *credentials.Credentials
 }
 
 // Run scans for restore candidates and restores them using a worker pool.
@@ -65,6 +66,8 @@ func Run(cfg *config.Config, dryRun bool, workers int, database *db.DB, download
 	}
 
 	// Pre-resolve remote IDs and credentials, build job queue.
+	// Credentials are cached per scan root to avoid repeated filesystem walks.
+	credCache := make(map[string]*credentials.Credentials)
 	var jobs []Job
 	for _, f := range scanRes.Files {
 		remoteID := f.RemoteID
@@ -92,20 +95,32 @@ func Run(cfg *config.Config, dryRun bool, workers int, database *db.DB, download
 			continue
 		}
 
-		// Find credentials for this file's scan root.
-		_, _, credErr := credentials.FindForPath(f.ScanRoot)
-		if credErr != nil {
-			res.SkippedNoCreds++
-			msg := fmt.Sprintf("%s: no credentials found: %v", f.Path, credErr)
-			res.ErrorDetails = append(res.ErrorDetails, msg)
-			if cfg.Verbose {
-				fmt.Fprintln(os.Stderr, msg)
+		// Find credentials for this file's scan root (cached).
+		creds, ok := credCache[f.ScanRoot]
+		if !ok {
+			var credErr error
+			creds, _, credErr = credentials.FindForPath(f.ScanRoot)
+			if credErr != nil {
+				res.SkippedNoCreds++
+				msg := fmt.Sprintf("%s: no credentials found: %v", f.Path, credErr)
+				res.ErrorDetails = append(res.ErrorDetails, msg)
+				if cfg.Verbose {
+					fmt.Fprintln(os.Stderr, msg)
+				}
+				// Cache a nil marker so we don't retry this scan root.
+				credCache[f.ScanRoot] = nil
+				continue
 			}
+			credCache[f.ScanRoot] = creds
+		}
+		if creds == nil {
+			res.SkippedNoCreds++
 			continue
 		}
 
 		jobs = append(jobs, Job{
-			File: f,
+			File:        f,
+			Credentials: creds,
 		})
 		res.Queued++
 	}
@@ -164,10 +179,9 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 		return fmt.Errorf("no remote file id")
 	}
 
-	// Resolve credentials.
-	creds, _, err := credentials.FindForPath(f.ScanRoot)
-	if err != nil {
-		return fmt.Errorf("credentials: %w", err)
+	creds := job.Credentials
+	if creds == nil {
+		return fmt.Errorf("no credentials available")
 	}
 
 	// Check disk space.

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1,0 +1,431 @@
+package restore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
+)
+
+type mockDownloader struct {
+	shouldFail bool
+	calls      []struct {
+		url  string
+		dest string
+	}
+}
+
+func (m *mockDownloader) Download(signedURL string, destPath string) error {
+	m.calls = append(m.calls, struct {
+		url  string
+		dest string
+	}{signedURL, destPath})
+	if m.shouldFail {
+		return fmt.Errorf("mock download failure")
+	}
+	// Write some content so size checks can pass.
+	return os.WriteFile(destPath, []byte("restored content"), 0644)
+}
+
+func TestRestoreDryRunDoesNotModify(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	createOldFile(t, filepath.Join(setDir, "4k", "video.mp4"))
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	// Override scanner to return a sparse-like file info without real hole punching.
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               filepath.Join(setDir, "4k", "video.mp4"),
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	downloader := &mockDownloader{}
+	res, err := Run(cfg, true, 1, nil, downloader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Candidates != 1 {
+		t.Errorf("expected 1 candidate, got %d", res.Candidates)
+	}
+	if res.Queued != 1 {
+		t.Errorf("expected 1 queued, got %d", res.Queued)
+	}
+	if len(downloader.calls) != 0 {
+		t.Error("dry-run should not call downloader")
+	}
+}
+
+func TestRestoreSkipsNoRemoteID(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+`)
+	createOldFile(t, filepath.Join(setDir, "4k", "video.mp4"))
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               filepath.Join(setDir, "4k", "video.mp4"),
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "",
+					Autograph:          -1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	res, err := Run(cfg, false, 1, nil, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedNoRemoteID != 1 {
+		t.Errorf("expected 1 skipped no remote id, got %d", res.SkippedNoRemoteID)
+	}
+}
+
+func TestRestoreUsesDBFallback(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "",
+					Autograph:          -1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	// Insert fallback record.
+	if err := database.UpsertOffloadedFile(path, "db-remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Run(cfg, true, 1, database, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedNoRemoteID != 0 {
+		t.Errorf("expected 0 skipped no remote id when DB fallback exists, got %d", res.SkippedNoRemoteID)
+	}
+	if res.Queued != 1 {
+		t.Errorf("expected 1 queued, got %d", res.Queued)
+	}
+}
+
+func TestRestoreWorkerTempFileRename(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	// Create credential file.
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               16,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	origDiskCheck := checkDiskSpace
+	checkDiskSpace = func(p string, n int64) (bool, int64, error) {
+		return true, 1024 * 1024 * 1024, nil
+	}
+	defer func() { checkDiskSpace = origDiskCheck }()
+
+	downloader := &mockDownloader{}
+	res, err := Run(cfg, false, 1, nil, downloader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Restored) != 1 {
+		t.Fatalf("expected 1 restored, got %d", len(res.Restored))
+	}
+	if res.Restored[0].Path != path {
+		t.Errorf("unexpected restored path: %s", res.Restored[0].Path)
+	}
+	if len(downloader.calls) != 1 {
+		t.Fatalf("expected 1 download call, got %d", len(downloader.calls))
+	}
+	if !filepath.IsAbs(downloader.calls[0].dest) {
+		t.Error("expected absolute temp path")
+	}
+	if filepath.Base(downloader.calls[0].dest) == filepath.Base(path) {
+		t.Error("downloader should write to temp file, not target directly")
+	}
+
+	// Ensure no leftover temp files.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestRestoreRecreatesMarkerWhenNoSpace(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	origDiskCheck := checkDiskSpace
+	checkDiskSpace = func(p string, n int64) (bool, int64, error) {
+		return false, 0, nil
+	}
+	defer func() { checkDiskSpace = origDiskCheck }()
+
+	res, err := Run(cfg, false, 1, nil, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedNoSpace != 1 {
+		t.Errorf("expected 1 skipped no space, got %d", res.SkippedNoSpace)
+	}
+
+	// Marker should be recreated.
+	if _, err := os.Stat(path + ".offloaded"); os.IsNotExist(err) {
+		t.Error("expected .offloaded marker to be recreated")
+	}
+}
+
+func TestRestoreMinimumAgeIgnored(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	// Create a brand new file (very young).
+	createFile(t, path, "new content")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(720 * time.Hour), // very old requirement
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	res, err := Run(cfg, true, 1, nil, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Candidates != 1 {
+		t.Errorf("expected 1 candidate (minimum age ignored), got %d", res.Candidates)
+	}
+}
+
+func createMarker(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".htaccess")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createFile(t *testing.T, path, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createOldFile(t *testing.T, path string) {
+	t.Helper()
+	createFile(t, path, "old content")
+	oldTime := time.Now().Add(-720 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createCredentialFile(t *testing.T, dir, clientID, clientSecret string) {
+	t.Helper()
+	content := fmt.Sprintf("[xvid]\nAPP_CLIENT_ID = \"%s\"\nAPP_CLIENT_SECRET = \"%s\"\n", clientID, clientSecret)
+	path := filepath.Join(dir, "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -10,9 +10,27 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
 	"github.com/mmilitzer/xvid-media-offload/pkg/marker"
+	"github.com/mmilitzer/xvid-media-offload/pkg/sparse"
 )
 
+// FileInfo represents a managed MP4 file found during scanning.
+type FileInfo struct {
+	Path               string
+	RelPath            string
+	Size               int64
+	ModTime            time.Time
+	Age                time.Duration
+	RemoteID           string
+	Autograph          int // -1 means not set, 0 or 1 means explicit value
+	Glob               string
+	MarkerPath         string
+	ScanRoot           string
+	IsSparse           bool
+	HasOffloadedMarker bool
+}
+
 // Candidate represents a file that is eligible for offloading.
+// Deprecated: use FileInfo directly for new code.
 type Candidate struct {
 	Path       string
 	RelPath    string
@@ -47,12 +65,24 @@ type Result struct {
 	ErrorDetails         []string
 }
 
+// ScanResult holds the outcome of a generalized scan.
+type ScanResult struct {
+	Files                []FileInfo
+	ManagedFolders       int
+	ValidMarkers         int
+	InvalidMarkers       int
+	SkippedMissingRemote int
+	Errors               int
+	ErrorDetails         []string
+}
+
 // Scan discovers offload candidates by looking for marker files at the
 // configured depth below each scan root, deriving candidate file paths
 // directly from the marker's RewriteRule patterns, and checking those
 // specific files.
 func Scan(cfg *config.Config) (*Result, error) {
-	if err := cfg.Validate(); err != nil {
+	all, err := ScanAll(cfg)
+	if err != nil {
 		return nil, err
 	}
 
@@ -60,8 +90,84 @@ func Scan(cfg *config.Config) (*Result, error) {
 		Candidates: make([]Candidate, 0),
 	}
 
+	res.ManagedFolders = all.ManagedFolders
+	res.ValidMarkers = all.ValidMarkers
+	res.InvalidMarkers = all.InvalidMarkers
+	res.SkippedMissingRemote = all.SkippedMissingRemote
+	res.Errors = all.Errors
+	res.ErrorDetails = all.ErrorDetails
+
+	for _, f := range all.Files {
+		// Skip files that don't exist on disk.
+		if f.Size < 0 {
+			res.SkippedMissingRemote++
+			if cfg.Verbose {
+				res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
+					Path:       f.Path,
+					MarkerPath: f.MarkerPath,
+					Reason:     "file not found on disk",
+				})
+			}
+			continue
+		}
+
+		// Skip already offloaded.
+		if f.HasOffloadedMarker {
+			res.SkippedOffloaded++
+			if cfg.Verbose {
+				res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
+					Path:       f.Path,
+					MarkerPath: f.MarkerPath,
+					Reason:     "already offloaded",
+				})
+			}
+			continue
+		}
+
+		// Skip too young.
+		if f.Age < cfg.MinimumAge.Duration() {
+			res.SkippedTooYoung++
+			if cfg.Verbose {
+				res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
+					Path:       f.Path,
+					MarkerPath: f.MarkerPath,
+					Reason:     "too young",
+				})
+			}
+			continue
+		}
+
+		res.Candidates = append(res.Candidates, Candidate{
+			Path:       f.Path,
+			RelPath:    f.RelPath,
+			Size:       f.Size,
+			ModTime:    f.ModTime,
+			Age:        f.Age,
+			RemoteID:   f.RemoteID,
+			Autograph:  f.Autograph,
+			Glob:       f.Glob,
+			MarkerPath: f.MarkerPath,
+		})
+		res.TotalCandidateSize += f.Size
+	}
+
+	return res, nil
+}
+
+// ScanAll performs a generalized scan and returns all managed MP4 files
+// with their full metadata, regardless of whether they are shrink or restore
+// candidates. It is the foundation for both shrink and restore modes.
+func ScanAll(cfg *config.Config) (*ScanResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	res := &ScanResult{
+		Files: make([]FileInfo, 0),
+	}
+
 	for _, root := range cfg.ScanRoots {
-		if err := scanRoot(root, cfg, res); err != nil {
+		if err := scanRootAll(root, cfg, res); err != nil {
 			return nil, fmt.Errorf("scanning root %s: %w", root, err)
 		}
 	}
@@ -69,7 +175,46 @@ func Scan(cfg *config.Config) (*Result, error) {
 	return res, nil
 }
 
-func scanRoot(root string, cfg *config.Config, res *Result) error {
+// ScanForRestore performs a scan and returns only files that are candidates
+// for restoration: sparse MP4 files without an .offloaded marker.
+func ScanForRestore(cfg *config.Config) (*ScanResult, error) {
+	all, err := ScanAll(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	restoreRes := &ScanResult{
+		ManagedFolders:       all.ManagedFolders,
+		ValidMarkers:         all.ValidMarkers,
+		InvalidMarkers:       all.InvalidMarkers,
+		SkippedMissingRemote: all.SkippedMissingRemote,
+		Errors:               all.Errors,
+		ErrorDetails:         all.ErrorDetails,
+		Files:                make([]FileInfo, 0),
+	}
+
+	for _, f := range all.Files {
+		// Skip files that don't exist on disk.
+		if f.Size < 0 {
+			restoreRes.SkippedMissingRemote++
+			continue
+		}
+
+		// Restore candidates must be sparse and not have an .offloaded marker.
+		if !f.IsSparse {
+			continue
+		}
+		if f.HasOffloadedMarker {
+			continue
+		}
+
+		restoreRes.Files = append(restoreRes.Files, f)
+	}
+
+	return restoreRes, nil
+}
+
+func scanRootAll(root string, cfg *config.Config, res *ScanResult) error {
 	root = filepath.Clean(root)
 
 	dirs, err := dirsAtDepth(root, cfg.MarkerDepth)
@@ -141,44 +286,20 @@ func scanRoot(root string, cfg *config.Config, res *Result) error {
 			absPath := filepath.Join(dirPath, filepath.FromSlash(relPath))
 
 			fileInfo, err := os.Stat(absPath)
-			if err != nil {
-				// File listed in marker but not present on disk.
-				res.SkippedMissingRemote++
-				if cfg.Verbose {
-					res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
-						Path:       absPath,
-						MarkerPath: markerPath,
-						Reason:     "file not found on disk",
-					})
-				}
-				continue
-			}
+			var size int64 = -1
+			var modTime time.Time
+			var age time.Duration
+			isSparse := false
+			hasOffloaded := false
 
-			// Check for .offloaded sibling.
-			if _, err := os.Stat(absPath + ".offloaded"); err == nil {
-				res.SkippedOffloaded++
-				if cfg.Verbose {
-					res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
-						Path:       absPath,
-						MarkerPath: markerPath,
-						Reason:     "already offloaded",
-					})
+			if err == nil {
+				size = fileInfo.Size()
+				modTime = fileInfo.ModTime()
+				age = time.Since(modTime)
+				isSparse, _ = sparse.IsSparse(absPath)
+				if _, err := os.Stat(absPath + ".offloaded"); err == nil {
+					hasOffloaded = true
 				}
-				continue
-			}
-
-			// Check minimum age.
-			age := time.Since(fileInfo.ModTime())
-			if age < cfg.MinimumAge.Duration() {
-				res.SkippedTooYoung++
-				if cfg.Verbose {
-					res.SkippedDetails = append(res.SkippedDetails, SkipInfo{
-						Path:       absPath,
-						MarkerPath: markerPath,
-						Reason:     "too young",
-					})
-				}
-				continue
 			}
 
 			remoteID := mInfo.FileIDByRel[pattern]
@@ -187,18 +308,20 @@ func scanRoot(root string, cfg *config.Config, res *Result) error {
 				autograph = a
 			}
 
-			res.Candidates = append(res.Candidates, Candidate{
-				Path:       absPath,
-				RelPath:    relToRoot,
-				Size:       fileInfo.Size(),
-				ModTime:    fileInfo.ModTime(),
-				Age:        age,
-				RemoteID:   remoteID,
-				Autograph:  autograph,
-				Glob:       matchedGlob,
-				MarkerPath: markerPath,
+			res.Files = append(res.Files, FileInfo{
+				Path:               absPath,
+				RelPath:            relToRoot,
+				Size:               size,
+				ModTime:            modTime,
+				Age:                age,
+				RemoteID:           remoteID,
+				Autograph:          autograph,
+				Glob:               matchedGlob,
+				MarkerPath:         markerPath,
+				ScanRoot:           root,
+				IsSparse:           isSparse,
+				HasOffloadedMarker: hasOffloaded,
 			})
-			res.TotalCandidateSize += fileInfo.Size()
 		}
 	}
 

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"golang.org/x/sys/unix"
 )
 
 func TestScanNoCandidates(t *testing.T) {
@@ -341,6 +342,156 @@ RewriteRule "^video.mp4" - [F,L,NC]
 	}
 }
 
+func TestScanAllReturnsAllFiles(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^video.mp4" - [F,L,NC]
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	createOldFile(t, filepath.Join(setDir, "video.mp4"))
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	res, err := ScanAll(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(res.Files))
+	}
+	if res.Files[0].Path != filepath.Join(setDir, "video.mp4") {
+		t.Errorf("unexpected path: %s", res.Files[0].Path)
+	}
+	if res.Files[0].HasOffloadedMarker {
+		t.Error("expected no offloaded marker")
+	}
+}
+
+func TestScanForRestoreIgnoresNonSparse(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^video.mp4" - [F,L,NC]
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	createOldFile(t, filepath.Join(setDir, "video.mp4"))
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	res, err := ScanForRestore(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Files) != 0 {
+		t.Errorf("expected 0 restore candidates for non-sparse file, got %d", len(res.Files))
+	}
+}
+
+func TestScanForRestoreIgnoresFilesWithMarker(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run hole-punch dependent tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^video.mp4" - [F,L,NC]
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "video.mp4")
+	createLargeOldFile(t, path)
+
+	// Punch a hole to make it sparse.
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	unix.Fallocate(int(f.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, 1024, 1024*1024)
+	f.Close()
+
+	// Create .offloaded marker.
+	createFile(t, path+".offloaded", "")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	res, err := ScanForRestore(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Files) != 0 {
+		t.Errorf("expected 0 restore candidates when .offloaded marker exists, got %d", len(res.Files))
+	}
+}
+
+func TestScanForRestoreFindsSparseWithoutMarker(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run hole-punch dependent tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^video.mp4" - [F,L,NC]
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "video.mp4")
+	createLargeOldFile(t, path)
+
+	// Punch a hole to make it sparse.
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unix.Fallocate(int(f.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, 1024, 1024*1024)
+	f.Close()
+
+	// Ensure .offloaded marker is absent.
+	os.Remove(path + ".offloaded")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	res, err := ScanForRestore(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Files) != 1 {
+		t.Fatalf("expected 1 restore candidate, got %d", len(res.Files))
+	}
+	if res.Files[0].Path != path {
+		t.Errorf("unexpected path: %s", res.Files[0].Path)
+	}
+}
+
 func TestScanIntegration(t *testing.T) {
 	// Build a self-contained directory tree so we control mtimes explicitly.
 	dir := t.TempDir()
@@ -455,6 +606,30 @@ func createFile(t *testing.T, path, content string) {
 func createOldFile(t *testing.T, path string) {
 	t.Helper()
 	createFile(t, path, "old content")
+	oldTime := time.Now().Add(-720 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createLargeOldFile(t *testing.T, path string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 2*1024*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
 	oldTime := time.Now().Add(-720 * time.Hour)
 	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
 		t.Fatal(err)

--- a/pkg/shrink/shrink.go
+++ b/pkg/shrink/shrink.go
@@ -58,7 +58,6 @@ func Run(cfg *config.Config, dryRun bool, database *db.DB) (*Result, error) {
 	}
 
 	res := &Result{
-		Candidates:           scanRes.Candidates,
 		ManagedFolders:       scanRes.ManagedFolders,
 		ValidMarkers:         scanRes.ValidMarkers,
 		InvalidMarkers:       scanRes.InvalidMarkers,
@@ -66,7 +65,6 @@ func Run(cfg *config.Config, dryRun bool, database *db.DB) (*Result, error) {
 		SkippedTooYoung:      scanRes.SkippedTooYoung,
 		SkippedMissingRemote: scanRes.SkippedMissingRemote,
 		Errors:               scanRes.Errors,
-		TotalCandidateSize:   scanRes.TotalCandidateSize,
 		SkippedDetails:       scanRes.SkippedDetails,
 		ErrorDetails:         scanRes.ErrorDetails,
 	}
@@ -121,8 +119,11 @@ func Run(cfg *config.Config, dryRun bool, database *db.DB) (*Result, error) {
 			continue
 		}
 
+		// File passes all shrink-specific checks — it is a real candidate.
+		res.Candidates = append(res.Candidates, c)
+		res.TotalCandidateSize += c.Size
+
 		if dryRun {
-			res.TotalCandidateSize += c.Size
 			continue
 		}
 

--- a/pkg/shrink/shrink_test.go
+++ b/pkg/shrink/shrink_test.go
@@ -127,6 +127,66 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	}
 }
 
+func TestShrinkDryRunSkipsSparseNotInCandidates(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	// Create a genuinely sparse file: write 1 byte then truncate to 1MB.
+	// On Linux tmpfs this yields st_blocks=1 (512 bytes) vs st_size=1MB,
+	// so sparse.IsSparse returns true without needing hole punching.
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	oldTime := time.Now().Add(-720 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	res, err := Run(cfg, true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The sparse file must be counted as skipped but NOT as a candidate.
+	if res.SkippedSparse != 1 {
+		t.Errorf("expected 1 sparse skip, got %d", res.SkippedSparse)
+	}
+	if len(res.Candidates) != 0 {
+		t.Errorf("expected 0 candidates (sparse file excluded), got %d", len(res.Candidates))
+	}
+	for _, c := range res.Candidates {
+		if c.Path == path {
+			t.Errorf("sparse file %s should not appear in Candidates", path)
+		}
+	}
+}
+
 func TestShrinkSkipsInvalidMarker(t *testing.T) {
 	dir := t.TempDir()
 	setDir := filepath.Join(dir, "set1")


### PR DESCRIPTION
## Summary

This PR implements Milestone 3: restore offloaded files by scanning for sparse MP4 files whose matching `.offloaded` marker file is missing, and restoring them from remote storage via signed temporary download URLs.

Closes #5

## What was implemented

### New CLI command
- `media-offload restore --config ./config.yaml`
- Supports `--dry-run`, `--verbose`, and `--workers` flags

### New packages

**`pkg/credentials`**
- Discovers `cmsinclude.ini.php` by walking upward from scan roots
- Parses PHP INI-style files to extract `APP_CLIENT_ID` and `APP_CLIENT_SECRET` from the `[xvid]` section

**`pkg/download`**
- HMAC-SHA256 URL signer following the documented Xvid MediaHub signing process
- `expert_mode=true` query parameter is added when `autograph=1`
- `HTTPDownloader` implementation with fsync after write
- `Downloader` interface is mockable for unit tests

**`pkg/restore`**
- Bounded worker pool (default 4 workers) for parallel restores
- Restore pipeline:
  1. Resolve remote file id (from marker or DB fallback)
  2. Resolve credentials for the scan root
  3. Check available disk space (`unix.Statfs`)
  4. If not enough space: recreate `.offloaded` marker and skip
  5. Generate signed temporary download URL
  6. Download to `filename.mp4.restore.<uuid>.tmp`
  7. Verify downloaded size against expected original size
  8. `fsync` temp file
  9. Atomically rename temp file over the sparse MP4
  10. `fsync` parent directory
  11. Update mtime to current time
  12. Remove DB fallback entry if present

### Refactored packages

**`pkg/scanner`**
- Added `FileInfo` struct with `IsSparse`, `HasOffloadedMarker`, and `ScanRoot`
- Added `ScanAll` for generalized scanning that serves both shrink and restore modes
- Added `ScanForRestore` which finds sparse MP4 files without `.offloaded` markers
- Existing `Scan()` preserves full backward compatibility

**`pkg/db`**
- Added `GetOffloadedFile` for DB fallback lookups during restore
- Added `DeleteOffloadedFile` to clean up entries after successful restore

**`cmd/media-offload`**
- Added `restore` command to the CLI

### Tests added
- Credentials parsing and directory-walk discovery
- HMAC signing with fixed test vectors (with and without `expert_mode`)
- Restore dry-run does not download or modify files
- Restore skips files with no resolvable remote ID
- Restore uses DB fallback when marker lacks remote ID
- Restore worker uses temp-file-then-rename behavior with mocked downloader
- Restore recreates `.offloaded` marker when disk space is insufficient
- Restore ignores `minimum_age` (important for future daemon mode)
- Scanner tests for `ScanAll` and `ScanForRestore`

## How it was tested

```bash
# All unit tests pass
go test ./...

# Hole-punch integration tests also pass
RUN_HOLE_PUNCH_TESTS=1 go test ./...

# CGO-free build succeeds
CGO_ENABLED=0 go build ./cmd/media-offload

# go vet clean
go vet ./...
```

## Acceptance criteria check

- [x] `go test ./...` passes
- [x] `CGO_ENABLED=0 go build ./cmd/media-offload` succeeds
- [x] Existing `scan` and `shrink` commands still work
- [x] New `restore` command works in dry-run mode
- [x] Restore can download through a mocked downloader in tests
- [x] Real restore code uses signed temporary URLs
- [x] `autograph=1` adds `expert_mode=true`
- [x] Credentials are discovered per scan root
- [x] No daemon mode or inotify implementation is included

---

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@mmilitzer can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ce6fdf88-bffc-4707-bcf6-c3f417eb30f8)