### PR TITLE
Implement Milestone 4: daemon mode with periodic scans, inotify, restore workers, and DB reconciliation

### DIFF
--- a/cmd/media-offload/main.go
+++ b/cmd/media-offload/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -408,6 +409,12 @@ func runDaemon(args []string) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
 		return 1
+	}
+
+	// Default lock file to the same directory as the config file so it is
+	// writable by the unprivileged user running the daemon.
+	if cfg.LockFile == "" {
+		cfg.LockFile = filepath.Join(filepath.Dir(*configPath), "media-offload.lock")
 	}
 
 	var database *db.DB

--- a/cmd/media-offload/main.go
+++ b/cmd/media-offload/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"github.com/mmilitzer/xvid-media-offload/pkg/daemon"
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
 	"github.com/mmilitzer/xvid-media-offload/pkg/download"
 	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
@@ -24,6 +25,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  scan    Scan for offload candidates")
 		fmt.Fprintln(os.Stderr, "  shrink  Offload eligible files by punching holes")
 		fmt.Fprintln(os.Stderr, "  restore Restore offloaded files from remote storage")
+		fmt.Fprintln(os.Stderr, "  daemon  Run continuous daemon with periodic scans and inotify")
 		os.Exit(1)
 	}
 
@@ -35,6 +37,8 @@ func main() {
 		os.Exit(runShrink(os.Args[2:]))
 	case "restore":
 		os.Exit(runRestore(os.Args[2:]))
+	case "daemon":
+		os.Exit(runDaemon(os.Args[2:]))
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
 		os.Exit(1)
@@ -384,4 +388,41 @@ func printRestoreReport(res *restore.Result, dryRun bool, verbose bool) {
 		}
 		fmt.Println()
 	}
+}
+
+func runDaemon(args []string) int {
+	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file (required)")
+	dryRun := fs.Bool("dry-run", false, "Report planned actions without modifying files")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %v\n", err)
+		return 1
+	}
+
+	if *configPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: --config is required")
+		return 1
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		return 1
+	}
+
+	var database *db.DB
+	if cfg.DatabasePath != "" {
+		database, err = db.Open(cfg.DatabasePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening database: %v\n", err)
+			return 1
+		}
+	}
+
+	d := daemon.NewDaemon(cfg, *dryRun, database, &download.HTTPDownloader{})
+	if err := d.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error running daemon: %v\n", err)
+		return 1
+	}
+	return 0
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,8 +19,11 @@ type Config struct {
 	DatabasePath    string   `yaml:"database_path"`
 	ScanInterval    Duration `yaml:"scan_interval"`
 	RestoreWorkers  int      `yaml:"restore_workers"`
-	LockFile        string   `yaml:"lock_file"`
-	Verbose         bool     `yaml:"-"` // set from CLI flag
+	// LockFile is the path to the daemon's advisory lock file.
+	// It must be writable by the user running the daemon.
+	// When empty, the daemon command defaults to a file next to the config.
+	LockFile string `yaml:"lock_file"`
+	Verbose  bool   `yaml:"-"` // set from CLI flag
 }
 
 // Load reads and parses a YAML configuration file.
@@ -46,7 +49,6 @@ const defaultMarkerFilename = ".htaccess"
 const defaultKeepPrefixBytes = 50 * 1024 * 1024 // 50 MB
 const defaultScanInterval = 24 * time.Hour
 const defaultRestoreWorkers = 4
-const defaultLockFile = "/var/run/media-offload.pid"
 
 // Validate checks that all required fields are present and valid.
 // Optional fields are set to their defaults when empty or zero.
@@ -77,9 +79,6 @@ func (c *Config) Validate() error {
 	}
 	if c.RestoreWorkers <= 0 {
 		c.RestoreWorkers = defaultRestoreWorkers
-	}
-	if c.LockFile == "" {
-		c.LockFile = defaultLockFile
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,6 +17,8 @@ type Config struct {
 	MinimumAge      Duration `yaml:"minimum_age"`
 	KeepPrefixBytes int64    `yaml:"keep_prefix_bytes"`
 	DatabasePath    string   `yaml:"database_path"`
+	ScanInterval    Duration `yaml:"scan_interval"`
+	RestoreWorkers  int      `yaml:"restore_workers"`
 	Verbose         bool     `yaml:"-"` // set from CLI flag
 }
 
@@ -40,6 +43,8 @@ func Load(path string) (*Config, error) {
 
 const defaultMarkerFilename = ".htaccess"
 const defaultKeepPrefixBytes = 50 * 1024 * 1024 // 50 MB
+const defaultScanInterval = 24 * time.Hour
+const defaultRestoreWorkers = 4
 
 // Validate checks that all required fields are present and valid.
 // Optional fields are set to their defaults when empty or zero.
@@ -64,6 +69,12 @@ func (c *Config) Validate() error {
 	}
 	if c.KeepPrefixBytes <= 0 {
 		c.KeepPrefixBytes = defaultKeepPrefixBytes
+	}
+	if c.ScanInterval.Duration() <= 0 {
+		c.ScanInterval = Duration(defaultScanInterval)
+	}
+	if c.RestoreWorkers <= 0 {
+		c.RestoreWorkers = defaultRestoreWorkers
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	DatabasePath    string   `yaml:"database_path"`
 	ScanInterval    Duration `yaml:"scan_interval"`
 	RestoreWorkers  int      `yaml:"restore_workers"`
+	LockFile        string   `yaml:"lock_file"`
 	Verbose         bool     `yaml:"-"` // set from CLI flag
 }
 
@@ -45,6 +46,7 @@ const defaultMarkerFilename = ".htaccess"
 const defaultKeepPrefixBytes = 50 * 1024 * 1024 // 50 MB
 const defaultScanInterval = 24 * time.Hour
 const defaultRestoreWorkers = 4
+const defaultLockFile = "/var/run/media-offload.pid"
 
 // Validate checks that all required fields are present and valid.
 // Optional fields are set to their defaults when empty or zero.
@@ -75,6 +77,9 @@ func (c *Config) Validate() error {
 	}
 	if c.RestoreWorkers <= 0 {
 		c.RestoreWorkers = defaultRestoreWorkers
+	}
+	if c.LockFile == "" {
+		c.LockFile = defaultLockFile
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -244,3 +244,65 @@ database_path: "/var/lib/media-offload/db.db"
 		t.Errorf("unexpected database_path: %s", cfg.DatabasePath)
 	}
 }
+
+func TestValidateScanIntervalDefault(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ScanInterval.Duration() != 24*time.Hour {
+		t.Errorf("expected default scan_interval 24h, got %v", cfg.ScanInterval.Duration())
+	}
+}
+
+func TestValidateRestoreWorkersDefault(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RestoreWorkers != 4 {
+		t.Errorf("expected default restore_workers 4, got %d", cfg.RestoreWorkers)
+	}
+}
+
+func TestLoadConfigWithDaemonFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `
+scan_roots:
+  - /tmp/scan1
+candidate_globs:
+  - "**/*.mp4"
+marker_filename: ".htaccess"
+minimum_age: "720h"
+keep_prefix_bytes: 52428800
+scan_interval: "6h"
+restore_workers: 8
+`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.ScanInterval.Duration() != 6*time.Hour {
+		t.Errorf("expected scan_interval 6h, got %v", cfg.ScanInterval.Duration())
+	}
+	if cfg.RestoreWorkers != 8 {
+		t.Errorf("expected restore_workers 8, got %d", cfg.RestoreWorkers)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mmilitzer/xvid-media-offload/pkg/credentials"
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
 	"github.com/mmilitzer/xvid-media-offload/pkg/download"
+	"github.com/mmilitzer/xvid-media-offload/pkg/lockfile"
 	"github.com/mmilitzer/xvid-media-offload/pkg/marker"
 	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
@@ -41,6 +42,8 @@ type Daemon struct {
 	// restoreCtx is cancelled on shutdown to abort active downloads.
 	restoreCtx    context.Context
 	restoreCancel context.CancelFunc
+
+	lock *lockfile.Lock
 
 	ticker *time.Ticker
 
@@ -84,6 +87,13 @@ func NewDaemon(cfg *config.Config, dryRun bool, database *db.DB, downloader down
 
 // Start begins the daemon and blocks until shutdown.
 func (d *Daemon) Start() error {
+	// Acquire single-instance lock before anything else.
+	lock, err := lockfile.Acquire(d.cfg.LockFile)
+	if err != nil {
+		return err
+	}
+	d.lock = lock
+
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	defer d.cancel()
 
@@ -184,6 +194,11 @@ func (d *Daemon) shutdown() {
 	// 7. Close DB.
 	if d.database != nil {
 		d.database.Close()
+	}
+
+	// 8. Release the single-instance lock.
+	if d.lock != nil {
+		_ = d.lock.Release()
 	}
 
 	log.Println("daemon stopped")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -33,6 +33,15 @@ type Daemon struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
+	// producerWg tracks goroutines that can enqueue into the restore queue
+	// (inotify reader, scan ticker callback). We wait for producers to stop
+	// before closing the queue to avoid send-on-closed-channel panics.
+	producerWg sync.WaitGroup
+
+	// restoreCtx is cancelled on shutdown to abort active downloads.
+	restoreCtx    context.Context
+	restoreCancel context.CancelFunc
+
 	ticker *time.Ticker
 
 	inotifyFd int
@@ -42,6 +51,9 @@ type Daemon struct {
 	queue      chan restoreJob
 	inFlight   map[string]bool
 	inFlightMu sync.Mutex
+
+	// overflowRescan signals that an inotify queue overflow occurred.
+	overflowRescan chan struct{}
 }
 
 type restoreJob struct {
@@ -56,13 +68,17 @@ type restoreJob struct {
 // NewDaemon creates a new daemon instance.
 func NewDaemon(cfg *config.Config, dryRun bool, database *db.DB, downloader download.Downloader) *Daemon {
 	return &Daemon{
-		cfg:        cfg,
-		dryRun:     dryRun,
-		database:   database,
-		downloader: downloader,
-		watches:    make(map[string]int),
-		queue:      make(chan restoreJob, 100),
-		inFlight:   make(map[string]bool),
+		cfg:            cfg,
+		dryRun:         dryRun,
+		database:       database,
+		downloader:     downloader,
+		inotifyFd:      -1,
+		watches:        make(map[string]int),
+		queue:          make(chan restoreJob, 100),
+		inFlight:       make(map[string]bool),
+		overflowRescan: make(chan struct{}, 1),
+		// Initialize ctx so tests that call enqueueRestore directly don't panic.
+		ctx: context.Background(),
 	}
 }
 
@@ -71,22 +87,16 @@ func (d *Daemon) Start() error {
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	defer d.cancel()
 
+	d.restoreCtx, d.restoreCancel = context.WithCancel(context.Background())
+	defer d.restoreCancel()
+
 	// Signal handling.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
 	log.Println("daemon starting")
 
-	// DB reconciliation.
-	if d.database != nil {
-		log.Println("startup DB reconciliation beginning")
-		if err := d.reconcileDB(); err != nil {
-			log.Printf("DB reconciliation error: %v", err)
-		}
-		log.Println("startup DB reconciliation complete")
-	}
-
-	// Start restore workers.
+	// Start restore workers FIRST so DB reconciliation and scans can enqueue.
 	for i := 0; i < d.cfg.RestoreWorkers; i++ {
 		d.wg.Add(1)
 		go d.restoreWorker()
@@ -96,8 +106,17 @@ func (d *Daemon) Start() error {
 	if err := d.startInotify(); err != nil {
 		log.Printf("inotify not available: %v", err)
 	} else {
-		d.wg.Add(1)
+		d.producerWg.Add(1)
 		go d.inotifyReader()
+	}
+
+	// DB reconciliation.
+	if d.database != nil {
+		log.Println("startup DB reconciliation beginning")
+		if err := d.reconcileDB(); err != nil {
+			log.Printf("DB reconciliation error: %v", err)
+		}
+		log.Println("startup DB reconciliation complete")
 	}
 
 	// Initial scan.
@@ -120,6 +139,9 @@ func (d *Daemon) Start() error {
 			return nil
 		case <-d.ticker.C:
 			d.runScan()
+		case <-d.overflowRescan:
+			log.Println("inotify queue overflow: scheduling full rescan")
+			d.runScan()
 		}
 	}
 }
@@ -133,17 +155,33 @@ func (d *Daemon) Stop() {
 
 func (d *Daemon) shutdown() {
 	log.Println("daemon shutting down")
-	d.cancel()
 
+	// 1. Cancel all contexts so producers and downloads stop.
+	if d.restoreCancel != nil {
+		d.restoreCancel()
+	}
+	if d.cancel != nil {
+		d.cancel()
+	}
+
+	// 2. Stop the ticker so no new scans are scheduled.
 	if d.ticker != nil {
 		d.ticker.Stop()
 	}
 
+	// 3. Stop inotify so no new events are produced.
 	d.stopInotify()
 
+	// 4. Wait for all producers to finish before closing the queue.
+	d.producerWg.Wait()
+
+	// 5. Close the queue so workers exit.
 	close(d.queue)
+
+	// 6. Wait for workers to drain.
 	d.wg.Wait()
 
+	// 7. Close DB.
 	if d.database != nil {
 		d.database.Close()
 	}
@@ -158,8 +196,15 @@ func (d *Daemon) runScan() {
 	d.combinedScan()
 }
 
-// enqueueRestore adds a restore job if not already in flight.
+// enqueueRestore adds a restore job if not already in flight and not shutting down.
 func (d *Daemon) enqueueRestore(job restoreJob) bool {
+	// Fast-path: if shutting down, don't enqueue.
+	select {
+	case <-d.ctx.Done():
+		return false
+	default:
+	}
+
 	d.inFlightMu.Lock()
 	if d.inFlight[job.Path] {
 		d.inFlightMu.Unlock()
@@ -177,6 +222,11 @@ func (d *Daemon) enqueueRestore(job restoreJob) bool {
 			log.Printf("restore enqueued: %s", job.Path)
 		}
 		return true
+	case <-d.ctx.Done():
+		d.inFlightMu.Lock()
+		delete(d.inFlight, job.Path)
+		d.inFlightMu.Unlock()
+		return false
 	default:
 		d.inFlightMu.Lock()
 		delete(d.inFlight, job.Path)
@@ -186,17 +236,38 @@ func (d *Daemon) enqueueRestore(job restoreJob) bool {
 	}
 }
 
+// enqueueRestoreBlocking adds a restore job, blocking until the queue has room
+// or the context is cancelled. Used by DB reconciliation to avoid silently
+// dropping jobs when the queue buffer is full.
+func (d *Daemon) enqueueRestoreBlocking(ctx context.Context, job restoreJob) bool {
+	d.inFlightMu.Lock()
+	if d.inFlight[job.Path] {
+		d.inFlightMu.Unlock()
+		log.Printf("duplicate restore skipped (in flight): %s", job.Path)
+		return false
+	}
+	d.inFlight[job.Path] = true
+	d.inFlightMu.Unlock()
+
+	select {
+	case d.queue <- job:
+		if d.dryRun {
+			log.Printf("dry-run: would enqueue restore: %s", job.Path)
+		} else {
+			log.Printf("restore enqueued: %s", job.Path)
+		}
+		return true
+	case <-ctx.Done():
+		d.inFlightMu.Lock()
+		delete(d.inFlight, job.Path)
+		d.inFlightMu.Unlock()
+		return false
+	}
+}
+
 func (d *Daemon) restoreWorker() {
 	defer d.wg.Done()
 	for job := range d.queue {
-		if d.ctx.Err() != nil {
-			// Shutting down; clear in-flight and stop.
-			d.inFlightMu.Lock()
-			delete(d.inFlight, job.Path)
-			d.inFlightMu.Unlock()
-			continue
-		}
-
 		if d.dryRun {
 			log.Printf("dry-run: would restore: %s", job.Path)
 			d.inFlightMu.Lock()
@@ -237,7 +308,19 @@ func (d *Daemon) runRestore(job restoreJob) error {
 		Credentials: creds,
 	}
 
-	_, err = restore.RestoreOne(rjob, d.cfg, d.database, d.downloader)
+	_, err = restore.RestoreOne(d.restoreCtx, rjob, d.cfg, d.database, d.downloader)
+	if err != nil {
+		// Clean up any partial temp file left behind by cancellation or failure.
+		dir := filepath.Dir(job.Path)
+		entries, readErr := os.ReadDir(dir)
+		if readErr == nil {
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), filepath.Base(job.Path)+".restore.") && strings.HasSuffix(e.Name(), ".tmp") {
+					_ = os.Remove(filepath.Join(dir, e.Name()))
+				}
+			}
+		}
+	}
 	return err
 }
 
@@ -256,6 +339,13 @@ func (d *Daemon) combinedScan() {
 		log.Printf("shrink error: %v", err)
 	} else if !d.dryRun && len(shrinkRes.Offloaded) > 0 {
 		log.Printf("shrink offloaded %d files", len(shrinkRes.Offloaded))
+		// Register inotify watches for newly offloaded files immediately.
+		for _, o := range shrinkRes.Offloaded {
+			dir := filepath.Dir(o.Path)
+			if err := d.addInotifyWatch(dir); err != nil {
+				log.Printf("inotify watch error for newly offloaded %s: %v", dir, err)
+			}
+		}
 	} else if d.dryRun && len(shrinkRes.Candidates) > 0 {
 		log.Printf("dry-run: would shrink %d files", len(shrinkRes.Candidates))
 	}
@@ -292,19 +382,16 @@ func (d *Daemon) combinedScan() {
 	}
 }
 
-// resolveRestoreJob attempts to build a restoreJob for a file path by reading
-// the marker file in its ancestor directories. It falls back to the DB if needed.
-func (d *Daemon) resolveRestoreJob(path string) (restoreJob, bool) {
+// findMarkerForPath walks upward from the file's directory looking for the
+// configured marker file. It returns the marker path and the directory it was
+// found in.
+func findMarkerForPath(path string, markerFilename string) (markerPath string, markerDir string) {
 	dir := filepath.Dir(path)
-
-	// Walk upward looking for the marker file.
-	var markerPath string
 	searchDir := dir
 	for {
-		candidate := filepath.Join(searchDir, d.cfg.MarkerFilename)
+		candidate := filepath.Join(searchDir, markerFilename)
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			markerPath = candidate
-			break
+			return candidate, searchDir
 		}
 		parent := filepath.Dir(searchDir)
 		if parent == searchDir {
@@ -312,6 +399,13 @@ func (d *Daemon) resolveRestoreJob(path string) (restoreJob, bool) {
 		}
 		searchDir = parent
 	}
+	return "", ""
+}
+
+// resolveRestoreJob attempts to build a restoreJob for a file path by reading
+// the marker file in its ancestor directories. It falls back to the DB if needed.
+func (d *Daemon) resolveRestoreJob(path string) (restoreJob, bool) {
+	markerPath, markerDir := findMarkerForPath(path, d.cfg.MarkerFilename)
 
 	var remoteID string
 	var autograph int = -1
@@ -319,7 +413,7 @@ func (d *Daemon) resolveRestoreJob(path string) (restoreJob, bool) {
 
 	if markerPath != "" {
 		if info, err := marker.Parse(markerPath); err == nil && info.Valid {
-			relPath, _ := filepath.Rel(filepath.Dir(markerPath), path)
+			relPath, _ := filepath.Rel(markerDir, path)
 			relPath = filepath.ToSlash(relPath)
 			if id, ok := info.MatchFileID(relPath); ok {
 				remoteID = id

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -241,63 +241,54 @@ func (d *Daemon) runRestore(job restoreJob) error {
 	return err
 }
 
-// combinedScan runs shrink and restore detection, registers inotify watches,
-// and enqueues restore jobs.
+// combinedScan performs a single filesystem walk and derives both shrink and
+// restore candidates from it, then registers inotify watches for .offloaded markers.
 func (d *Daemon) combinedScan() {
-	// Shrink pass: reuse existing shrink logic.
-	if !d.dryRun {
-		res, err := shrink.Run(d.cfg, false, d.database)
-		if err != nil {
-			log.Printf("shrink scan error: %v", err)
-		} else if len(res.Offloaded) > 0 {
-			log.Printf("shrink offloaded %d files", len(res.Offloaded))
-		}
-	} else {
-		res, err := shrink.Run(d.cfg, true, d.database)
-		if err != nil {
-			log.Printf("shrink scan error: %v", err)
-		} else if len(res.Candidates) > 0 {
-			log.Printf("dry-run: would shrink %d files", len(res.Candidates))
-		}
-	}
-
-	// Restore pass: find sparse files without .offloaded markers.
-	scanRes, err := scanner.ScanForRestore(d.cfg)
-	if err != nil {
-		log.Printf("restore scan error: %v", err)
-		return
-	}
-
-	if len(scanRes.Files) > 0 {
-		log.Printf("restore scan found %d candidates", len(scanRes.Files))
-	}
-
-	for _, f := range scanRes.Files {
-		job := restoreJob{
-			Path:       f.Path,
-			RemoteID:   f.RemoteID,
-			Autograph:  f.Autograph,
-			Size:       f.Size,
-			MarkerPath: f.MarkerPath,
-			ScanRoot:   f.ScanRoot,
-		}
-		d.enqueueRestore(job)
-	}
-
-	// Inotify: register watches on parent dirs of .offloaded markers.
 	all, err := scanner.ScanAll(d.cfg)
 	if err != nil {
-		log.Printf("inotify scan error: %v", err)
+		log.Printf("combined scan error: %v", err)
 		return
 	}
 
+	// Shrink processing from the same ScanAll result.
+	shrinkRes, err := shrink.RunFromAll(d.cfg, d.dryRun, d.database, all)
+	if err != nil {
+		log.Printf("shrink error: %v", err)
+	} else if !d.dryRun && len(shrinkRes.Offloaded) > 0 {
+		log.Printf("shrink offloaded %d files", len(shrinkRes.Offloaded))
+	} else if d.dryRun && len(shrinkRes.Candidates) > 0 {
+		log.Printf("dry-run: would shrink %d files", len(shrinkRes.Candidates))
+	}
+
+	// Restore candidates and inotify watches derived from the same ScanAll result.
+	restoreCount := 0
 	for _, f := range all.Files {
+		if f.Size < 0 {
+			continue
+		}
 		if f.HasOffloadedMarker {
 			dir := filepath.Dir(f.Path)
 			if err := d.addInotifyWatch(dir); err != nil {
 				log.Printf("inotify watch error for %s: %v", dir, err)
 			}
+			continue
 		}
+		if f.IsSparse {
+			restoreCount++
+			job := restoreJob{
+				Path:       f.Path,
+				RemoteID:   f.RemoteID,
+				Autograph:  f.Autograph,
+				Size:       f.Size,
+				MarkerPath: f.MarkerPath,
+				ScanRoot:   f.ScanRoot,
+			}
+			d.enqueueRestore(job)
+		}
+	}
+
+	if restoreCount > 0 {
+		log.Printf("restore scan found %d candidates", restoreCount)
 	}
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,0 +1,378 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"github.com/mmilitzer/xvid-media-offload/pkg/credentials"
+	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/download"
+	"github.com/mmilitzer/xvid-media-offload/pkg/marker"
+	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
+	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
+	"github.com/mmilitzer/xvid-media-offload/pkg/shrink"
+)
+
+// Daemon runs the media-offload service in continuous mode.
+type Daemon struct {
+	cfg        *config.Config
+	dryRun     bool
+	database   *db.DB
+	downloader download.Downloader
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	ticker *time.Ticker
+
+	inotifyFd int
+	watches   map[string]int // dirPath -> watch descriptor
+	watchesMu sync.Mutex
+
+	queue      chan restoreJob
+	inFlight   map[string]bool
+	inFlightMu sync.Mutex
+}
+
+type restoreJob struct {
+	Path       string
+	RemoteID   string
+	Autograph  int
+	Size       int64
+	MarkerPath string
+	ScanRoot   string
+}
+
+// NewDaemon creates a new daemon instance.
+func NewDaemon(cfg *config.Config, dryRun bool, database *db.DB, downloader download.Downloader) *Daemon {
+	return &Daemon{
+		cfg:        cfg,
+		dryRun:     dryRun,
+		database:   database,
+		downloader: downloader,
+		watches:    make(map[string]int),
+		queue:      make(chan restoreJob, 100),
+		inFlight:   make(map[string]bool),
+	}
+}
+
+// Start begins the daemon and blocks until shutdown.
+func (d *Daemon) Start() error {
+	d.ctx, d.cancel = context.WithCancel(context.Background())
+	defer d.cancel()
+
+	// Signal handling.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	log.Println("daemon starting")
+
+	// DB reconciliation.
+	if d.database != nil {
+		log.Println("startup DB reconciliation beginning")
+		if err := d.reconcileDB(); err != nil {
+			log.Printf("DB reconciliation error: %v", err)
+		}
+		log.Println("startup DB reconciliation complete")
+	}
+
+	// Start restore workers.
+	for i := 0; i < d.cfg.RestoreWorkers; i++ {
+		d.wg.Add(1)
+		go d.restoreWorker()
+	}
+
+	// Start inotify reader if supported.
+	if err := d.startInotify(); err != nil {
+		log.Printf("inotify not available: %v", err)
+	} else {
+		d.wg.Add(1)
+		go d.inotifyReader()
+	}
+
+	// Initial scan.
+	d.runScan()
+
+	// Periodic scans.
+	d.ticker = time.NewTicker(d.cfg.ScanInterval.Duration())
+	defer d.ticker.Stop()
+
+	log.Printf("daemon running, scan interval: %v", d.cfg.ScanInterval.Duration())
+
+	for {
+		select {
+		case <-sigCh:
+			log.Println("daemon received shutdown signal")
+			d.shutdown()
+			return nil
+		case <-d.ctx.Done():
+			d.shutdown()
+			return nil
+		case <-d.ticker.C:
+			d.runScan()
+		}
+	}
+}
+
+// Stop initiates a clean shutdown of the daemon.
+func (d *Daemon) Stop() {
+	if d.cancel != nil {
+		d.cancel()
+	}
+}
+
+func (d *Daemon) shutdown() {
+	log.Println("daemon shutting down")
+	d.cancel()
+
+	if d.ticker != nil {
+		d.ticker.Stop()
+	}
+
+	d.stopInotify()
+
+	close(d.queue)
+	d.wg.Wait()
+
+	if d.database != nil {
+		d.database.Close()
+	}
+
+	log.Println("daemon stopped")
+}
+
+func (d *Daemon) runScan() {
+	log.Println("scan beginning")
+	defer log.Println("scan complete")
+
+	d.combinedScan()
+}
+
+// enqueueRestore adds a restore job if not already in flight.
+func (d *Daemon) enqueueRestore(job restoreJob) bool {
+	d.inFlightMu.Lock()
+	if d.inFlight[job.Path] {
+		d.inFlightMu.Unlock()
+		log.Printf("duplicate restore skipped (in flight): %s", job.Path)
+		return false
+	}
+	d.inFlight[job.Path] = true
+	d.inFlightMu.Unlock()
+
+	select {
+	case d.queue <- job:
+		if d.dryRun {
+			log.Printf("dry-run: would enqueue restore: %s", job.Path)
+		} else {
+			log.Printf("restore enqueued: %s", job.Path)
+		}
+		return true
+	default:
+		d.inFlightMu.Lock()
+		delete(d.inFlight, job.Path)
+		d.inFlightMu.Unlock()
+		log.Printf("restore queue full, skipping: %s", job.Path)
+		return false
+	}
+}
+
+func (d *Daemon) restoreWorker() {
+	defer d.wg.Done()
+	for job := range d.queue {
+		if d.ctx.Err() != nil {
+			// Shutting down; clear in-flight and stop.
+			d.inFlightMu.Lock()
+			delete(d.inFlight, job.Path)
+			d.inFlightMu.Unlock()
+			continue
+		}
+
+		if d.dryRun {
+			log.Printf("dry-run: would restore: %s", job.Path)
+			d.inFlightMu.Lock()
+			delete(d.inFlight, job.Path)
+			d.inFlightMu.Unlock()
+			continue
+		}
+
+		if err := d.runRestore(job); err != nil {
+			log.Printf("restore failed: %s: %v", job.Path, err)
+		} else {
+			log.Printf("restore complete: %s", job.Path)
+		}
+
+		d.inFlightMu.Lock()
+		delete(d.inFlight, job.Path)
+		d.inFlightMu.Unlock()
+	}
+}
+
+func (d *Daemon) runRestore(job restoreJob) error {
+	creds, _, err := credentials.FindForPath(job.Path)
+	if err != nil {
+		return fmt.Errorf("no credentials: %w", err)
+	}
+
+	fileInfo := scanner.FileInfo{
+		Path:       job.Path,
+		Size:       job.Size,
+		RemoteID:   job.RemoteID,
+		Autograph:  job.Autograph,
+		MarkerPath: job.MarkerPath,
+		ScanRoot:   job.ScanRoot,
+	}
+
+	rjob := restore.Job{
+		File:        fileInfo,
+		Credentials: creds,
+	}
+
+	_, err = restore.RestoreOne(rjob, d.cfg, d.database, d.downloader)
+	return err
+}
+
+// combinedScan runs shrink and restore detection, registers inotify watches,
+// and enqueues restore jobs.
+func (d *Daemon) combinedScan() {
+	// Shrink pass: reuse existing shrink logic.
+	if !d.dryRun {
+		res, err := shrink.Run(d.cfg, false, d.database)
+		if err != nil {
+			log.Printf("shrink scan error: %v", err)
+		} else if len(res.Offloaded) > 0 {
+			log.Printf("shrink offloaded %d files", len(res.Offloaded))
+		}
+	} else {
+		res, err := shrink.Run(d.cfg, true, d.database)
+		if err != nil {
+			log.Printf("shrink scan error: %v", err)
+		} else if len(res.Candidates) > 0 {
+			log.Printf("dry-run: would shrink %d files", len(res.Candidates))
+		}
+	}
+
+	// Restore pass: find sparse files without .offloaded markers.
+	scanRes, err := scanner.ScanForRestore(d.cfg)
+	if err != nil {
+		log.Printf("restore scan error: %v", err)
+		return
+	}
+
+	if len(scanRes.Files) > 0 {
+		log.Printf("restore scan found %d candidates", len(scanRes.Files))
+	}
+
+	for _, f := range scanRes.Files {
+		job := restoreJob{
+			Path:       f.Path,
+			RemoteID:   f.RemoteID,
+			Autograph:  f.Autograph,
+			Size:       f.Size,
+			MarkerPath: f.MarkerPath,
+			ScanRoot:   f.ScanRoot,
+		}
+		d.enqueueRestore(job)
+	}
+
+	// Inotify: register watches on parent dirs of .offloaded markers.
+	all, err := scanner.ScanAll(d.cfg)
+	if err != nil {
+		log.Printf("inotify scan error: %v", err)
+		return
+	}
+
+	for _, f := range all.Files {
+		if f.HasOffloadedMarker {
+			dir := filepath.Dir(f.Path)
+			if err := d.addInotifyWatch(dir); err != nil {
+				log.Printf("inotify watch error for %s: %v", dir, err)
+			}
+		}
+	}
+}
+
+// resolveRestoreJob attempts to build a restoreJob for a file path by reading
+// the marker file in its ancestor directories. It falls back to the DB if needed.
+func (d *Daemon) resolveRestoreJob(path string) (restoreJob, bool) {
+	dir := filepath.Dir(path)
+
+	// Walk upward looking for the marker file.
+	var markerPath string
+	searchDir := dir
+	for {
+		candidate := filepath.Join(searchDir, d.cfg.MarkerFilename)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			markerPath = candidate
+			break
+		}
+		parent := filepath.Dir(searchDir)
+		if parent == searchDir {
+			break
+		}
+		searchDir = parent
+	}
+
+	var remoteID string
+	var autograph int = -1
+	var size int64
+
+	if markerPath != "" {
+		if info, err := marker.Parse(markerPath); err == nil && info.Valid {
+			relPath, _ := filepath.Rel(filepath.Dir(markerPath), path)
+			relPath = filepath.ToSlash(relPath)
+			if id, ok := info.MatchFileID(relPath); ok {
+				remoteID = id
+			}
+			if a, ok := info.MatchAutograph(relPath); ok {
+				autograph = a
+			}
+		}
+	}
+
+	if remoteID == "" && d.database != nil {
+		if dbRemoteID, dbAutograph, dbSize, _, err := d.database.GetOffloadedFile(path); err == nil {
+			remoteID = dbRemoteID
+			autograph = dbAutograph
+			size = dbSize
+		}
+	}
+
+	if remoteID == "" {
+		return restoreJob{}, false
+	}
+
+	if size == 0 {
+		if fi, err := os.Stat(path); err == nil {
+			size = fi.Size()
+		}
+	}
+
+	// Determine scan root.
+	scanRoot := ""
+	for _, root := range d.cfg.ScanRoots {
+		root = filepath.Clean(root)
+		if strings.HasPrefix(path, root+string(filepath.Separator)) {
+			scanRoot = root
+			break
+		}
+	}
+
+	return restoreJob{
+		Path:       path,
+		RemoteID:   remoteID,
+		Autograph:  autograph,
+		Size:       size,
+		MarkerPath: markerPath,
+		ScanRoot:   scanRoot,
+	}, true
+}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,445 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mmilitzer/xvid-media-offload/pkg/config"
+	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/shrink"
+	"github.com/mmilitzer/xvid-media-offload/pkg/sparse"
+)
+
+func TestEnqueueRestoreDedup(t *testing.T) {
+	cfg := &config.Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, nil, nil)
+
+	job := restoreJob{Path: "/media/video.mp4", RemoteID: "abc123"}
+
+	if !d.enqueueRestore(job) {
+		t.Fatal("expected first enqueue to succeed")
+	}
+	if d.enqueueRestore(job) {
+		t.Fatal("expected duplicate enqueue to fail")
+	}
+
+	// Simulate worker completion.
+	d.inFlightMu.Lock()
+	delete(d.inFlight, job.Path)
+	d.inFlightMu.Unlock()
+
+	if !d.enqueueRestore(job) {
+		t.Fatal("expected re-enqueue after completion to succeed")
+	}
+}
+
+func TestResolveRestoreJobFromMarker(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, nil, nil)
+	job, ok := d.resolveRestoreJob(path)
+	if !ok {
+		t.Fatal("expected resolve to succeed")
+	}
+	if job.Path != path {
+		t.Errorf("unexpected path: %s", job.Path)
+	}
+	if job.RemoteID != "669872d3d3586a56f9a3dfad" {
+		t.Errorf("unexpected remote id: %s", job.RemoteID)
+	}
+	if job.Autograph != 1 {
+		t.Errorf("unexpected autograph: %d", job.Autograph)
+	}
+}
+
+func TestResolveRestoreJobFallbackToDB(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "video.mp4")
+	createOldFile(t, path)
+
+	// No marker file.
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.UpsertOffloadedFile(path, "db-remote-id", 0, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	job, ok := d.resolveRestoreJob(path)
+	if !ok {
+		t.Fatal("expected resolve to succeed via DB fallback")
+	}
+	if job.RemoteID != "db-remote-id" {
+		t.Errorf("unexpected remote id: %s", job.RemoteID)
+	}
+	if job.Autograph != 0 {
+		t.Errorf("unexpected autograph: %d", job.Autograph)
+	}
+}
+
+func TestReconcileMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	path := filepath.Join(dir, "missing.mp4")
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	_, _, _, _, err = database.GetOffloadedFile(path)
+	if err == nil {
+		t.Error("expected DB record to be removed for missing file")
+	}
+}
+
+func TestReconcileRestoredFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	path := filepath.Join(dir, "video.mp4")
+	if err := os.WriteFile(path, []byte("full content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 12, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 12}
+	d.reconcileRecord(rec)
+
+	_, _, _, _, err = database.GetOffloadedFile(path)
+	if err == nil {
+		t.Error("expected DB record to be removed for restored file")
+	}
+}
+
+func TestReconcileStillOffloaded(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	path := filepath.Join(dir, "video.mp4")
+	createSparseFile(t, path)
+
+	// Create .offloaded marker.
+	if err := os.WriteFile(path+".offloaded", []byte("offloaded"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	_, _, _, _, err = database.GetOffloadedFile(path)
+	if err != nil {
+		t.Error("expected DB record to remain for still-offloaded file")
+	}
+}
+
+func TestReconcileDBOnlyRecovery(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	path := filepath.Join(dir, "video.mp4")
+	createSparseFile(t, path)
+
+	// No .offloaded marker, no .htaccess marker.
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	// Should be enqueued; verify in-flight.
+	d.inFlightMu.Lock()
+	inFlight := d.inFlight[path]
+	d.inFlightMu.Unlock()
+	if !inFlight {
+		t.Error("expected DB-only recovery to enqueue restore job")
+	}
+}
+
+func TestReconcileDryRun(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	path := filepath.Join(dir, "missing.mp4")
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, true, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	_, _, _, _, err = database.GetOffloadedFile(path)
+	if err != nil {
+		t.Error("expected DB record to remain in dry-run mode")
+	}
+}
+
+func TestDaemonStartStop(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, nil, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.Start()
+	}()
+
+	// Give it a moment to start.
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error from Start: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("daemon did not stop in time")
+	}
+}
+
+func TestCombinedScanMinimumAgeOnlyForShrink(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	// Create a brand new file (very young).
+	createFile(t, path, "new content")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(720 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	// For restore, make the file appear sparse.
+	// We can't easily make a real sparse file in tests without hole punching,
+	// so we test via scanner.ScanForRestore which uses sparse.IsSparse.
+	// Since the file is tiny and not sparse, ScanForRestore won't find it.
+	// This test verifies that shrink.Run in dry-run finds 0 candidates because of minimum_age.
+	res, err := shrink.Run(cfg, true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Candidates) != 0 {
+		t.Errorf("expected 0 shrink candidates for young file, got %d", len(res.Candidates))
+	}
+}
+
+func createMarker(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".htaccess")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createFile(t *testing.T, path, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createOldFile(t *testing.T, path string) {
+	t.Helper()
+	createFile(t, path, "old content")
+	oldTime := time.Now().Add(-720 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createSparseFile(t *testing.T, path string) {
+	t.Helper()
+	createFile(t, path, "sparse content")
+	// Create a file that appears sparse by making it large with minimal content.
+	// sparse.IsSparse uses allocated blocks * 512 < 0.8 * size.
+	// For a tiny file, it won't appear sparse. We need to actually punch a hole.
+	// On Linux, we can use fallocate to create a sparse file.
+	// But in CI this may not be supported. Instead, we create a larger file
+	// and try to punch a hole if supported.
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Write 1 byte at offset 1024*1024 to create a 1MB file with 1 block allocated.
+	if _, err := f.WriteAt([]byte("x"), 1024*1024); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// Verify it appears sparse.
+	isSparse, err := sparse.IsSparse(path)
+	if err != nil {
+		t.Fatalf("sparse check failed: %v", err)
+	}
+	if !isSparse {
+		// If filesystem doesn't support sparse detection, skip.
+		t.Skip("filesystem does not support sparse file detection")
+	}
+}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -441,5 +443,310 @@ func createSparseFile(t *testing.T, path string) {
 	if !isSparse {
 		// If filesystem doesn't support sparse detection, skip.
 		t.Skip("filesystem does not support sparse file detection")
+	}
+}
+
+// cancellableDownloader blocks until its context is cancelled, then returns the ctx error.
+type cancellableDownloader struct {
+	started chan struct{}
+}
+
+func (c *cancellableDownloader) Download(signedURL string, destPath string) error {
+	return c.DownloadContext(context.Background(), signedURL, destPath)
+}
+
+func (c *cancellableDownloader) DownloadContext(ctx context.Context, signedURL string, destPath string) error {
+	close(c.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestShutdownCancelsActiveRestore(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	// Create a sparse file so the initial scan enqueues a restore job.
+	createSparseFile(t, path)
+
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	downloader := &cancellableDownloader{started: make(chan struct{})}
+	d := NewDaemon(cfg, false, nil, downloader)
+
+	// Start the daemon in background.
+	done := make(chan error, 1)
+	go func() {
+		done <- d.Start()
+	}()
+
+	// Wait for the downloader to start (meaning restore is active).
+	select {
+	case <-downloader.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("downloader did not start")
+	}
+
+	// Create a temp file to verify cleanup.
+	tmpPath := path + ".restore.abc123.tmp"
+	if err := os.WriteFile(tmpPath, []byte("partial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger shutdown while restore is in progress.
+	d.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not stop in time")
+	}
+
+	// Verify the partial temp file was cleaned up.
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected partial temp file to be deleted after shutdown cancellation")
+	}
+}
+
+func TestEnqueueRestoreNoPanicAfterShutdown(t *testing.T) {
+	cfg := &config.Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, nil, nil)
+
+	// Start and immediately stop to set ctx to cancelled.
+	go d.Start()
+	time.Sleep(50 * time.Millisecond)
+	d.Stop()
+
+	// Give shutdown time to cancel ctx but not necessarily close queue yet.
+	time.Sleep(50 * time.Millisecond)
+
+	// Enqueue should not panic; it should return false because ctx is done.
+	job := restoreJob{Path: "/media/video.mp4", RemoteID: "abc123"}
+	if d.enqueueRestore(job) {
+		t.Error("expected enqueue to fail after shutdown")
+	}
+}
+
+func TestReconcileDBOnlyBlockingWithFullQueue(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	// Create 5 sparse files with DB records but no markers.
+	paths := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("video%d.mp4", i))
+		createSparseFile(t, paths[i])
+		if err := database.UpsertOffloadedFile(paths[i], fmt.Sprintf("remote-id-%d", i), 1, 100, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	// Use a tiny queue so blocking is required.
+	d.queue = make(chan restoreJob, 1)
+
+	// Start a slow worker so the queue fills up.
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		for job := range d.queue {
+			time.Sleep(100 * time.Millisecond)
+			d.inFlightMu.Lock()
+			delete(d.inFlight, job.Path)
+			d.inFlightMu.Unlock()
+		}
+	}()
+
+	// Reconciliation should block but eventually enqueue all 5 jobs.
+	d.reconcileDB()
+
+	// Wait for all jobs to be processed.
+	close(d.queue)
+	d.wg.Wait()
+
+	// All 5 should have been enqueued and processed.
+	for _, p := range paths {
+		d.inFlightMu.Lock()
+		inFlight := d.inFlight[p]
+		d.inFlightMu.Unlock()
+		if inFlight {
+			t.Errorf("expected job for %s to be processed", p)
+		}
+	}
+}
+
+func TestNewlyOffloadedFilesGetWatchedImmediately(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run apply-mode shrink tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	// Create a large enough old file.
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 4*1024*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	oldTime := time.Now().Add(-720 * time.Hour)
+	os.Chtimes(path, oldTime, oldTime)
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1024 * 1024,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	d := NewDaemon(cfg, false, database, nil)
+
+	// Start inotify manually.
+	if err := d.startInotify(); err != nil {
+		t.Skipf("inotify not available: %v", err)
+	}
+
+	// Run combined scan in apply mode.
+	d.combinedScan()
+
+	// Verify the file was offloaded.
+	if _, err := os.Stat(path + ".offloaded"); os.IsNotExist(err) {
+		t.Fatal("expected .offloaded marker to be created")
+	}
+
+	// Verify inotify watch was registered for the parent directory.
+	d.watchesMu.Lock()
+	_, watched := d.watches[filepath.Dir(path)]
+	d.watchesMu.Unlock()
+	if !watched {
+		t.Error("expected parent dir of newly offloaded file to be watched immediately")
+	}
+
+	d.stopInotify()
+}
+
+func TestReconcileMarkerLookupInSubdirectory(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	// Marker is in setDir, file is in setDir/4k/.
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createSparseFile(t, path)
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+
+	// The marker lookup should walk upward from setDir/4k/ to setDir/ and find
+	// the file id, so this should be treated as Case 4 (marker has file id) and
+	// NOT enqueued for DB-only recovery.
+	d.reconcileRecord(rec)
+
+	d.inFlightMu.Lock()
+	inFlight := d.inFlight[path]
+	d.inFlightMu.Unlock()
+	if inFlight {
+		t.Error("expected reconcile to find marker in parent dir and NOT enqueue DB-only recovery")
+	}
+}
+
+func createCredentialFile(t *testing.T, dir, clientID, clientSecret string) {
+	t.Helper()
+	content := fmt.Sprintf("[xvid]\nAPP_CLIENT_ID = \"%s\"\nAPP_CLIENT_SECRET = \"%s\"\n", clientID, clientSecret)
+	path := filepath.Join(dir, "cmsinclude.ini.php")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -694,6 +694,73 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	d.stopInotify()
 }
 
+func TestReconcileWatchesOffloadedFileWhenMarkerMissing(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	// Create marker initially so the file gets offloaded.
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createSparseFile(t, path)
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now delete the main marker so the scan won't find this folder.
+	if err := os.Remove(filepath.Join(setDir, ".htaccess")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .offloaded marker to simulate an intentionally offloaded file.
+	if err := os.WriteFile(path+".offloaded", []byte("offloaded"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+		LockFile:        filepath.Join(t.TempDir(), "daemon.lock"),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+
+	// Start inotify manually.
+	if err := d.startInotify(); err != nil {
+		t.Skipf("inotify not available: %v", err)
+	}
+
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	// Verify the parent directory got watched.
+	d.watchesMu.Lock()
+	_, watched := d.watches[filepath.Dir(path)]
+	d.watchesMu.Unlock()
+	if !watched {
+		t.Error("expected parent dir to be watched during reconciliation of offloaded file")
+	}
+
+	d.stopInotify()
+}
+
 func TestReconcileMarkerLookupInSubdirectory(t *testing.T) {
 	dir := t.TempDir()
 	setDir := filepath.Join(dir, "set1")

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -323,6 +323,7 @@ func TestDaemonStartStop(t *testing.T) {
 		KeepPrefixBytes: 1,
 		RestoreWorkers:  1,
 		ScanInterval:    config.Duration(24 * time.Hour),
+		LockFile:        filepath.Join(t.TempDir(), "daemon.lock"),
 	}
 
 	d := NewDaemon(cfg, false, nil, nil)
@@ -484,6 +485,7 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 		KeepPrefixBytes: 1,
 		RestoreWorkers:  1,
 		ScanInterval:    config.Duration(24 * time.Hour),
+		LockFile:        filepath.Join(t.TempDir(), "daemon.lock"),
 	}
 
 	downloader := &cancellableDownloader{started: make(chan struct{})}
@@ -532,6 +534,7 @@ func TestEnqueueRestoreNoPanicAfterShutdown(t *testing.T) {
 		KeepPrefixBytes: 1,
 		RestoreWorkers:  1,
 		ScanInterval:    config.Duration(24 * time.Hour),
+		LockFile:        filepath.Join(t.TempDir(), "daemon.lock"),
 	}
 
 	d := NewDaemon(cfg, false, nil, nil)

--- a/pkg/daemon/inotify.go
+++ b/pkg/daemon/inotify.go
@@ -49,7 +49,7 @@ func (d *Daemon) addInotifyWatch(dir string) error {
 }
 
 func (d *Daemon) inotifyReader() {
-	defer d.wg.Done()
+	defer d.producerWg.Done()
 
 	if d.inotifyFd < 0 {
 		return
@@ -98,6 +98,13 @@ func (d *Daemon) inotifyReader() {
 		for offset < n {
 			event := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
 			nameLen := int(event.Len)
+			if event.Mask&unix.IN_Q_OVERFLOW != 0 {
+				log.Printf("inotify: queue overflow detected")
+				select {
+				case d.overflowRescan <- struct{}{}:
+				default:
+				}
+			}
 			if nameLen > 0 {
 				nameBytes := buf[offset+unix.SizeofInotifyEvent : offset+unix.SizeofInotifyEvent+nameLen]
 				name := string(bytes.TrimRight(nameBytes, "\x00"))

--- a/pkg/daemon/inotify.go
+++ b/pkg/daemon/inotify.go
@@ -1,0 +1,158 @@
+package daemon
+
+import (
+	"bytes"
+	"log"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func (d *Daemon) startInotify() error {
+	fd, err := unix.InotifyInit1(unix.IN_CLOEXEC | unix.IN_NONBLOCK)
+	if err != nil {
+		return err
+	}
+	d.inotifyFd = fd
+	return nil
+}
+
+func (d *Daemon) stopInotify() {
+	if d.inotifyFd >= 0 {
+		unix.Close(d.inotifyFd)
+		d.inotifyFd = -1
+	}
+}
+
+func (d *Daemon) addInotifyWatch(dir string) error {
+	d.watchesMu.Lock()
+	defer d.watchesMu.Unlock()
+
+	if d.inotifyFd < 0 {
+		return nil // inotify not available
+	}
+
+	if _, ok := d.watches[dir]; ok {
+		return nil // already watching
+	}
+
+	mask := uint32(unix.IN_DELETE | unix.IN_MOVED_FROM | unix.IN_IGNORED)
+	wd, err := unix.InotifyAddWatch(d.inotifyFd, dir, mask)
+	if err != nil {
+		return err
+	}
+
+	d.watches[dir] = wd
+	return nil
+}
+
+func (d *Daemon) inotifyReader() {
+	defer d.wg.Done()
+
+	if d.inotifyFd < 0 {
+		return
+	}
+
+	var buf [(unix.SizeofInotifyEvent + unix.NAME_MAX + 1) * 20]byte
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		default:
+		}
+
+		// Poll with 1-second timeout so we can check for shutdown regularly.
+		pfd := []unix.PollFd{{Fd: int32(d.inotifyFd), Events: unix.POLLIN}}
+		_, err := unix.Poll(pfd, 1000)
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			log.Printf("inotify poll error: %v", err)
+			return
+		}
+
+		if pfd[0].Revents&(unix.POLLNVAL|unix.POLLERR) != 0 {
+			return
+		}
+		if pfd[0].Revents&unix.POLLIN == 0 {
+			continue
+		}
+
+		n, err := unix.Read(d.inotifyFd, buf[:])
+		if err != nil {
+			if err == unix.EAGAIN || err == unix.EINTR {
+				continue
+			}
+			log.Printf("inotify read error: %v", err)
+			return
+		}
+		if n <= 0 {
+			continue
+		}
+
+		offset := 0
+		for offset < n {
+			event := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			nameLen := int(event.Len)
+			if nameLen > 0 {
+				nameBytes := buf[offset+unix.SizeofInotifyEvent : offset+unix.SizeofInotifyEvent+nameLen]
+				name := string(bytes.TrimRight(nameBytes, "\x00"))
+				d.handleInotifyEvent(int(event.Wd), name, event.Mask)
+			}
+			offset += unix.SizeofInotifyEvent + nameLen
+		}
+	}
+}
+
+func (d *Daemon) handleInotifyEvent(wd int, name string, mask uint32) {
+	if mask&unix.IN_IGNORED != 0 {
+		d.watchesMu.Lock()
+		for dir, id := range d.watches {
+			if id == wd {
+				delete(d.watches, dir)
+				break
+			}
+		}
+		d.watchesMu.Unlock()
+		return
+	}
+
+	if mask&unix.IN_DELETE == 0 && mask&unix.IN_MOVED_FROM == 0 {
+		return
+	}
+
+	if !strings.HasSuffix(name, ".offloaded") {
+		return
+	}
+
+	d.watchesMu.Lock()
+	var dir string
+	for dDir, id := range d.watches {
+		if id == wd {
+			dir = dDir
+			break
+		}
+	}
+	d.watchesMu.Unlock()
+
+	if dir == "" {
+		return
+	}
+
+	base := strings.TrimSuffix(name, ".offloaded")
+	filePath := filepath.Join(dir, base)
+
+	log.Printf("inotify: .offloaded deleted for %s", filePath)
+
+	job, ok := d.resolveRestoreJob(filePath)
+	if !ok {
+		log.Printf("inotify: unable to resolve restore job for %s", filePath)
+		return
+	}
+
+	d.enqueueRestore(job)
+}

--- a/pkg/daemon/reconcile.go
+++ b/pkg/daemon/reconcile.go
@@ -70,7 +70,11 @@ func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
 	hasOffloadedMarker := offloadedMarkerErr == nil
 
 	if hasOffloadedMarker {
-		// Case 3: still intentionally offloaded. Do nothing.
+		// Case 3: still intentionally offloaded.
+		// Register an inotify watch on the parent directory so we are notified
+		// when the .offloaded marker is deleted, even if the main marker file
+		// was removed and the normal scan no longer finds this folder.
+		_ = d.addInotifyWatch(filepath.Dir(path))
 		return
 	}
 

--- a/pkg/daemon/reconcile.go
+++ b/pkg/daemon/reconcile.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/marker"
+	"github.com/mmilitzer/xvid-media-offload/pkg/sparse"
+)
+
+// reconcileDB performs startup reconciliation between the database and the filesystem.
+func (d *Daemon) reconcileDB() error {
+	records, err := d.database.ListAllOffloadedFiles()
+	if err != nil {
+		return err
+	}
+
+	for _, rec := range records {
+		d.reconcileRecord(rec)
+	}
+
+	return nil
+}
+
+func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
+	path := rec.LocalPath
+
+	// Case 1: MP4 file no longer exists.
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if d.dryRun {
+			log.Printf("dry-run DB reconcile: would remove DB row for missing file %s", path)
+			return
+		}
+		if err := d.database.DeleteOffloadedFile(path); err != nil {
+			log.Printf("DB reconcile: failed to delete row for missing file %s: %v", path, err)
+		} else {
+			log.Printf("DB reconcile: removed row for missing file %s", path)
+		}
+		return
+	}
+
+	isSparse, err := sparse.IsSparse(path)
+	if err != nil {
+		log.Printf("DB reconcile: sparse check failed for %s: %v", path, err)
+		return
+	}
+
+	// Case 2: MP4 exists and is no longer sparse, size matches original.
+	if !isSparse {
+		fi, err := os.Stat(path)
+		if err == nil && fi.Size() == rec.OriginalSize {
+			if d.dryRun {
+				log.Printf("dry-run DB reconcile: would remove DB row for restored file %s", path)
+				return
+			}
+			if err := d.database.DeleteOffloadedFile(path); err != nil {
+				log.Printf("DB reconcile: failed to delete row for restored file %s: %v", path, err)
+			} else {
+				log.Printf("DB reconcile: removed row for restored file %s", path)
+			}
+		}
+		return
+	}
+
+	// File is sparse.
+	offloadedMarkerPath := path + ".offloaded"
+	_, offloadedMarkerErr := os.Stat(offloadedMarkerPath)
+	hasOffloadedMarker := offloadedMarkerErr == nil
+
+	if hasOffloadedMarker {
+		// Case 3: still intentionally offloaded. Do nothing.
+		return
+	}
+
+	// .offloaded marker is missing.
+	dir := filepath.Dir(path)
+	markerPath := filepath.Join(dir, d.cfg.MarkerFilename)
+	mInfo, err := marker.Parse(markerPath)
+	markerValid := err == nil && mInfo.Valid
+	markerHasFileID := false
+	if markerValid {
+		relPath, _ := filepath.Rel(dir, path)
+		relPath = filepath.ToSlash(relPath)
+		_, markerHasFileID = mInfo.MatchFileID(relPath)
+	}
+
+	if markerValid && markerHasFileID {
+		// Case 4: marker exists with file id. Normal scan will handle it.
+		return
+	}
+
+	// Case 5: DB-only recovery.
+	if d.dryRun {
+		log.Printf("dry-run DB reconcile: would enqueue DB-only restore for %s", path)
+		return
+	}
+
+	job := restoreJob{
+		Path:       path,
+		RemoteID:   rec.RemoteFileID,
+		Autograph:  rec.Autograph,
+		Size:       rec.OriginalSize,
+		MarkerPath: markerPath,
+	}
+	d.enqueueRestore(job)
+	log.Printf("DB reconcile: enqueued DB-only restore for %s", path)
+}

--- a/pkg/daemon/reconcile.go
+++ b/pkg/daemon/reconcile.go
@@ -74,14 +74,13 @@ func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
 		return
 	}
 
-	// .offloaded marker is missing.
-	dir := filepath.Dir(path)
-	markerPath := filepath.Join(dir, d.cfg.MarkerFilename)
+	// .offloaded marker is missing. Walk upward to find the main marker file.
+	markerPath, markerDir := findMarkerForPath(path, d.cfg.MarkerFilename)
 	mInfo, err := marker.Parse(markerPath)
 	markerValid := err == nil && mInfo.Valid
 	markerHasFileID := false
-	if markerValid {
-		relPath, _ := filepath.Rel(dir, path)
+	if markerValid && markerDir != "" {
+		relPath, _ := filepath.Rel(markerDir, path)
 		relPath = filepath.ToSlash(relPath)
 		_, markerHasFileID = mInfo.MatchFileID(relPath)
 	}
@@ -104,6 +103,6 @@ func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
 		Size:       rec.OriginalSize,
 		MarkerPath: markerPath,
 	}
-	d.enqueueRestore(job)
+	d.enqueueRestoreBlocking(d.ctx, job)
 	log.Printf("DB reconcile: enqueued DB-only restore for %s", path)
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -80,6 +80,41 @@ func (db *DB) DeleteOffloadedFile(localPath string) error {
 	return err
 }
 
+// OffloadedRecord represents a single row from the offloaded_files table.
+type OffloadedRecord struct {
+	LocalPath     string
+	RemoteFileID  string
+	Autograph     int
+	OriginalSize  int64
+	OffloadedAt   time.Time
+}
+
+// ListAllOffloadedFiles returns all records in the offloaded_files table.
+func (db *DB) ListAllOffloadedFiles() ([]OffloadedRecord, error) {
+	rows, err := db.conn.Query(`
+		SELECT local_path, remote_file_id, autograph, original_size, offloaded_at_unix
+		FROM offloaded_files
+		ORDER BY local_path
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []OffloadedRecord
+	for rows.Next() {
+		var r OffloadedRecord
+		var offloadedAtUnix int64
+		err := rows.Scan(&r.LocalPath, &r.RemoteFileID, &r.Autograph, &r.OriginalSize, &offloadedAtUnix)
+		if err != nil {
+			return nil, err
+		}
+		r.OffloadedAt = time.Unix(offloadedAtUnix, 0)
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
 // Close closes the database connection.
 func (db *DB) Close() error {
 	return db.conn.Close()

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -13,14 +14,15 @@ import (
 )
 
 const (
-	apiBaseURL     = "https://api.xvid.com"
-	signPath       = "/v1/files/downloads/"
-	defaultExpiry  = 30 * time.Minute
+	apiBaseURL    = "https://api.xvid.com"
+	signPath      = "/v1/files/downloads/"
+	defaultExpiry = 30 * time.Minute
 )
 
 // Downloader is the interface for downloading files. It can be mocked in tests.
 type Downloader interface {
 	Download(signedURL string, destPath string) error
+	DownloadContext(ctx context.Context, signedURL string, destPath string) error
 }
 
 // HTTPDownloader implements Downloader using the standard HTTP client.
@@ -30,12 +32,22 @@ type HTTPDownloader struct {
 
 // Download downloads the resource at signedURL to destPath.
 func (d *HTTPDownloader) Download(signedURL string, destPath string) error {
+	return d.DownloadContext(context.Background(), signedURL, destPath)
+}
+
+// DownloadContext downloads the resource at signedURL to destPath, respecting ctx.
+func (d *HTTPDownloader) DownloadContext(ctx context.Context, signedURL string, destPath string) error {
 	client := d.Client
 	if client == nil {
 		client = http.DefaultClient
 	}
 
-	resp, err := client.Get(signedURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, signedURL, nil)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("http GET: %w", err)
 	}

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -1,0 +1,40 @@
+package lockfile
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// Lock represents an advisory file lock held by the daemon.
+type Lock struct {
+	fd   int
+	path string
+}
+
+// Acquire opens or creates the lock file and acquires an exclusive,
+// non-blocking flock. If another process holds the lock, it returns an error.
+func Acquire(path string) (*Lock, error) {
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CREAT, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file %s: %w", path, err)
+	}
+
+	err = unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB)
+	if err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("daemon already running (lock file %s is held)", path)
+	}
+
+	return &Lock{fd: fd, path: path}, nil
+}
+
+// Release closes the lock file descriptor, releasing the flock.
+func (l *Lock) Release() error {
+	if l.fd < 0 {
+		return nil
+	}
+	err := unix.Close(l.fd)
+	l.fd = -1
+	return err
+}

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -1,0 +1,59 @@
+package lockfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLockAcquireAndRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+
+	lock, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring lock: %v", err)
+	}
+	defer lock.Release()
+
+	// File should exist.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected lock file to exist: %v", err)
+	}
+}
+
+func TestLockExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+
+	lock1, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring first lock: %v", err)
+	}
+	defer lock1.Release()
+
+	// Second acquire should fail.
+	lock2, err := Acquire(path)
+	if err == nil {
+		lock2.Release()
+		t.Fatal("expected second lock acquisition to fail")
+	}
+}
+
+func TestLockReleasedAllowsReacquire(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+
+	lock1, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring first lock: %v", err)
+	}
+
+	if err := lock1.Release(); err != nil {
+		t.Fatalf("unexpected error releasing lock: %v", err)
+	}
+
+	// After release, re-acquire should succeed.
+	lock2, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("unexpected error re-acquiring lock: %v", err)
+	}
+	defer lock2.Release()
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -164,11 +165,11 @@ func Run(cfg *config.Config, dryRun bool, workers int, database *db.DB, download
 }
 
 // RestoreOne performs a single-file restore and returns details about the restored file.
-func RestoreOne(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
-	return restoreOne(job, cfg, database, downloader)
+func RestoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
+	return restoreOne(ctx, job, cfg, database, downloader)
 }
 
-func restoreOne(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
+func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
 	f := job.File
 
 	// Resolve remote ID and autograph again inside worker.
@@ -216,7 +217,7 @@ func restoreOne(job Job, cfg *config.Config, database *db.DB, downloader downloa
 
 	// Download to temp file.
 	tempPath := f.Path + ".restore." + uuid.NewString() + ".tmp"
-	err = downloader.Download(signedURL, tempPath)
+	err = downloader.DownloadContext(ctx, signedURL, tempPath)
 	if err != nil {
 		os.Remove(tempPath)
 		return RestoreInfo{}, fmt.Errorf("download: %w", err)
@@ -269,7 +270,7 @@ func restoreOne(job Job, cfg *config.Config, database *db.DB, downloader downloa
 }
 
 func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader, res *Result, mu *sync.Mutex) error {
-	info, err := restoreOne(job, cfg, database, downloader)
+	info, err := restoreOne(context.Background(), job, cfg, database, downloader)
 	if err != nil {
 		if strings.Contains(err.Error(), "not enough disk space") {
 			mu.Lock()

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -215,6 +215,18 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 		return RestoreInfo{}, fmt.Errorf("signing URL: %w", err)
 	}
 
+	// Before downloading, clean up any stale temp files left by previous
+	// crashed or interrupted restore attempts.
+	baseName := filepath.Base(f.Path)
+	dir := filepath.Dir(f.Path)
+	if entries, readErr := os.ReadDir(dir); readErr == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), baseName+".restore.") && strings.HasSuffix(e.Name(), ".tmp") {
+				_ = os.Remove(filepath.Join(dir, e.Name()))
+			}
+		}
+	}
+
 	// Download to temp file.
 	tempPath := f.Path + ".restore." + uuid.NewString() + ".tmp"
 	err = downloader.DownloadContext(ctx, signedURL, tempPath)
@@ -244,7 +256,7 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 	}
 
 	// Fsync directory.
-	dir := filepath.Dir(f.Path)
+	dir = filepath.Dir(f.Path)
 	dirFile, err := os.Open(dir)
 	if err == nil {
 		unix.Fsync(int(dirFile.Fd()))

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -191,6 +191,18 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 		return RestoreInfo{}, fmt.Errorf("no credentials available")
 	}
 
+	// Clean up any stale temp files left by previous crashed or interrupted
+	// restore attempts before checking disk space.
+	baseName := filepath.Base(f.Path)
+	dir := filepath.Dir(f.Path)
+	if entries, readErr := os.ReadDir(dir); readErr == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), baseName+".restore.") && strings.HasSuffix(e.Name(), ".tmp") {
+				_ = os.Remove(filepath.Join(dir, e.Name()))
+			}
+		}
+	}
+
 	// Check disk space.
 	enough, avail, err := checkDiskSpace(f.Path, f.Size)
 	if err != nil {
@@ -215,18 +227,6 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 		return RestoreInfo{}, fmt.Errorf("signing URL: %w", err)
 	}
 
-	// Before downloading, clean up any stale temp files left by previous
-	// crashed or interrupted restore attempts.
-	baseName := filepath.Base(f.Path)
-	dir := filepath.Dir(f.Path)
-	if entries, readErr := os.ReadDir(dir); readErr == nil {
-		for _, e := range entries {
-			if strings.HasPrefix(e.Name(), baseName+".restore.") && strings.HasSuffix(e.Name(), ".tmp") {
-				_ = os.Remove(filepath.Join(dir, e.Name()))
-			}
-		}
-	}
-
 	// Download to temp file.
 	tempPath := f.Path + ".restore." + uuid.NewString() + ".tmp"
 	err = downloader.DownloadContext(ctx, signedURL, tempPath)
@@ -245,6 +245,14 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 		if fi.Size() != f.Size {
 			os.Remove(tempPath)
 			return RestoreInfo{}, fmt.Errorf("size mismatch: expected %d, got %d", f.Size, fi.Size())
+		}
+	}
+
+	// Preserve the original file's permissions on the temp file before rename.
+	if origInfo, statErr := os.Stat(f.Path); statErr == nil {
+		if chmodErr := os.Chmod(tempPath, origInfo.Mode()); chmodErr != nil {
+			os.Remove(tempPath)
+			return RestoreInfo{}, fmt.Errorf("chmod temp file: %w", chmodErr)
 		}
 	}
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -162,7 +163,12 @@ func Run(cfg *config.Config, dryRun bool, workers int, database *db.DB, download
 	return res, nil
 }
 
-func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader, res *Result, mu *sync.Mutex) error {
+// RestoreOne performs a single-file restore and returns details about the restored file.
+func RestoreOne(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
+	return restoreOne(job, cfg, database, downloader)
+}
+
+func restoreOne(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader) (RestoreInfo, error) {
 	f := job.File
 
 	// Resolve remote ID and autograph again inside worker.
@@ -176,29 +182,26 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 		}
 	}
 	if remoteID == "" {
-		return fmt.Errorf("no remote file id")
+		return RestoreInfo{}, fmt.Errorf("no remote file id")
 	}
 
 	creds := job.Credentials
 	if creds == nil {
-		return fmt.Errorf("no credentials available")
+		return RestoreInfo{}, fmt.Errorf("no credentials available")
 	}
 
 	// Check disk space.
 	enough, avail, err := checkDiskSpace(f.Path, f.Size)
 	if err != nil {
-		return fmt.Errorf("disk space check: %w", err)
+		return RestoreInfo{}, fmt.Errorf("disk space check: %w", err)
 	}
 	if !enough {
 		// Recreate .offloaded marker and skip.
 		err = os.WriteFile(f.Path+".offloaded", []byte(offloadedMarkerContent), 0644)
 		if err != nil {
-			return fmt.Errorf("not enough space (%d bytes available) and failed to recreate marker: %w", avail, err)
+			return RestoreInfo{}, fmt.Errorf("not enough space (%d bytes available) and failed to recreate marker: %w", avail, err)
 		}
-		mu.Lock()
-		res.SkippedNoSpace++
-		mu.Unlock()
-		return nil
+		return RestoreInfo{}, fmt.Errorf("not enough disk space (%d bytes available)", avail)
 	}
 
 	// Sign download URL.
@@ -208,7 +211,7 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 	}
 	signedURL, err := signer.SignURL(remoteID, autograph == 1)
 	if err != nil {
-		return fmt.Errorf("signing URL: %w", err)
+		return RestoreInfo{}, fmt.Errorf("signing URL: %w", err)
 	}
 
 	// Download to temp file.
@@ -216,7 +219,7 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 	err = downloader.Download(signedURL, tempPath)
 	if err != nil {
 		os.Remove(tempPath)
-		return fmt.Errorf("download: %w", err)
+		return RestoreInfo{}, fmt.Errorf("download: %w", err)
 	}
 
 	// Verify size if known.
@@ -224,11 +227,11 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 		fi, err := os.Stat(tempPath)
 		if err != nil {
 			os.Remove(tempPath)
-			return fmt.Errorf("stat temp file: %w", err)
+			return RestoreInfo{}, fmt.Errorf("stat temp file: %w", err)
 		}
 		if fi.Size() != f.Size {
 			os.Remove(tempPath)
-			return fmt.Errorf("size mismatch: expected %d, got %d", f.Size, fi.Size())
+			return RestoreInfo{}, fmt.Errorf("size mismatch: expected %d, got %d", f.Size, fi.Size())
 		}
 	}
 
@@ -236,7 +239,7 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 	err = os.Rename(tempPath, f.Path)
 	if err != nil {
 		os.Remove(tempPath)
-		return fmt.Errorf("atomic rename: %w", err)
+		return RestoreInfo{}, fmt.Errorf("atomic rename: %w", err)
 	}
 
 	// Fsync directory.
@@ -256,16 +259,29 @@ func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader downloa
 		_ = database.DeleteOffloadedFile(f.Path)
 	}
 
-	mu.Lock()
-	res.Restored = append(res.Restored, RestoreInfo{
+	return RestoreInfo{
 		Path:       f.Path,
 		RemoteID:   remoteID,
 		Autograph:  autograph,
 		Size:       f.Size,
 		MarkerPath: f.MarkerPath,
-	})
-	mu.Unlock()
+	}, nil
+}
 
+func restoreJob(job Job, cfg *config.Config, database *db.DB, downloader download.Downloader, res *Result, mu *sync.Mutex) error {
+	info, err := restoreOne(job, cfg, database, downloader)
+	if err != nil {
+		if strings.Contains(err.Error(), "not enough disk space") {
+			mu.Lock()
+			res.SkippedNoSpace++
+			mu.Unlock()
+			return nil
+		}
+		return err
+	}
+	mu.Lock()
+	res.Restored = append(res.Restored, info)
+	mu.Unlock()
 	return nil
 }
 

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1,6 +1,7 @@
 package restore
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,10 @@ type mockDownloader struct {
 }
 
 func (m *mockDownloader) Download(signedURL string, destPath string) error {
+	return m.DownloadContext(context.Background(), signedURL, destPath)
+}
+
+func (m *mockDownloader) DownloadContext(ctx context.Context, signedURL string, destPath string) error {
 	m.calls = append(m.calls, struct {
 		url  string
 		dest string

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -395,6 +395,77 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	}
 }
 
+func TestRestoreCleansStaleTempBeforeDiskCheck(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	// Create a stale large temp file that would make disk check fail if not cleaned.
+	staleTemp := path + ".restore.stale-uuid.tmp"
+	if err := os.WriteFile(staleTemp, make([]byte, 1024*1024), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               16,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	// Mock disk check to fail if the stale temp still exists.
+	origDiskCheck := checkDiskSpace
+	checkDiskSpace = func(p string, n int64) (bool, int64, error) {
+		if _, err := os.Stat(staleTemp); err == nil {
+			return false, 0, nil
+		}
+		return true, 1024 * 1024 * 1024, nil
+	}
+	defer func() { checkDiskSpace = origDiskCheck }()
+
+	downloader := &mockDownloader{}
+	res, err := Run(cfg, false, 1, nil, downloader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Restored) != 1 {
+		t.Fatalf("expected 1 restored, got %d", len(res.Restored))
+	}
+	if _, err := os.Stat(staleTemp); !os.IsNotExist(err) {
+		t.Error("expected stale temp file to be cleaned before disk check")
+	}
+}
+
 func createMarker(t *testing.T, dir, content string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/pkg/shrink/shrink.go
+++ b/pkg/shrink/shrink.go
@@ -69,7 +69,58 @@ func Run(cfg *config.Config, dryRun bool, database *db.DB) (*Result, error) {
 		ErrorDetails:         scanRes.ErrorDetails,
 	}
 
-	for _, c := range scanRes.Candidates {
+	return processCandidates(cfg, dryRun, database, scanRes.Candidates, res)
+}
+
+// RunFromAll performs shrink processing using a pre-computed ScanAll result.
+// It derives shrink candidates from the ScanResult and applies the same
+// shrink-specific checks as Run, avoiding a second filesystem walk.
+func RunFromAll(cfg *config.Config, dryRun bool, database *db.DB, all *scanner.ScanResult) (*Result, error) {
+	var candidates []scanner.Candidate
+	var skippedOffloaded, skippedTooYoung, skippedMissingRemote int
+
+	for _, f := range all.Files {
+		if f.Size < 0 {
+			skippedMissingRemote++
+			continue
+		}
+		if f.HasOffloadedMarker {
+			skippedOffloaded++
+			continue
+		}
+		if f.Age < cfg.MinimumAge.Duration() {
+			skippedTooYoung++
+			continue
+		}
+		candidates = append(candidates, scanner.Candidate{
+			Path:       f.Path,
+			RelPath:    f.RelPath,
+			Size:       f.Size,
+			ModTime:    f.ModTime,
+			Age:        f.Age,
+			RemoteID:   f.RemoteID,
+			Autograph:  f.Autograph,
+			Glob:       f.Glob,
+			MarkerPath: f.MarkerPath,
+		})
+	}
+
+	res := &Result{
+		ManagedFolders:       all.ManagedFolders,
+		ValidMarkers:         all.ValidMarkers,
+		InvalidMarkers:       all.InvalidMarkers,
+		SkippedOffloaded:     skippedOffloaded,
+		SkippedTooYoung:      skippedTooYoung,
+		SkippedMissingRemote: skippedMissingRemote,
+		Errors:               all.Errors,
+		ErrorDetails:         all.ErrorDetails,
+	}
+
+	return processCandidates(cfg, dryRun, database, candidates, res)
+}
+
+func processCandidates(cfg *config.Config, dryRun bool, database *db.DB, candidates []scanner.Candidate, res *Result) (*Result, error) {
+	for _, c := range candidates {
 		// Skip files that are too small.
 		if c.Size <= 2*cfg.KeepPrefixBytes {
 			res.SkippedTooSmall++

--- a/pkg/shrink/shrink_test.go
+++ b/pkg/shrink/shrink_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
+	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
 )
 
 func TestShrinkDryRunDoesNotModify(t *testing.T) {
@@ -371,5 +372,60 @@ func createOldFile(t *testing.T, path string) {
 	oldTime := time.Now().Add(-720 * time.Hour)
 	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRunFromAllProducesSameDryRunResults(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	createOldFile(t, filepath.Join(setDir, "4k", "video.mp4"))
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	// Run via the traditional two-pass path.
+	resRun, err := Run(cfg, true, nil)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	// Run via single-pass RunFromAll.
+	all, err := scanner.ScanAll(cfg)
+	if err != nil {
+		t.Fatalf("ScanAll error: %v", err)
+	}
+	resFromAll, err := RunFromAll(cfg, true, nil, all)
+	if err != nil {
+		t.Fatalf("RunFromAll error: %v", err)
+	}
+
+	if len(resFromAll.Candidates) != len(resRun.Candidates) {
+		t.Errorf("expected %d candidates from RunFromAll, got %d", len(resRun.Candidates), len(resFromAll.Candidates))
+	}
+	if resFromAll.ManagedFolders != resRun.ManagedFolders {
+		t.Errorf("ManagedFolders mismatch: %d vs %d", resFromAll.ManagedFolders, resRun.ManagedFolders)
+	}
+	if resFromAll.ValidMarkers != resRun.ValidMarkers {
+		t.Errorf("ValidMarkers mismatch: %d vs %d", resFromAll.ValidMarkers, resRun.ValidMarkers)
+	}
+	if resFromAll.SkippedOffloaded != resRun.SkippedOffloaded {
+		t.Errorf("SkippedOffloaded mismatch: %d vs %d", resFromAll.SkippedOffloaded, resRun.SkippedOffloaded)
+	}
+	if resFromAll.SkippedTooYoung != resRun.SkippedTooYoung {
+		t.Errorf("SkippedTooYoung mismatch: %d vs %d", resFromAll.SkippedTooYoung, resRun.SkippedTooYoung)
+	}
+	if resFromAll.SkippedMissingRemote != resRun.SkippedMissingRemote {
+		t.Errorf("SkippedMissingRemote mismatch: %d vs %d", resFromAll.SkippedMissingRemote, resRun.SkippedMissingRemote)
 	}
 }


### PR DESCRIPTION
This PR implements Issue #7 / Milestone 4.

## What was implemented

- **Daemon command** (`cmd/media-offload`): New `daemon` subcommand with `--config` and `--dry-run` flags. Runs in the foreground and exits cleanly on SIGTERM/SIGINT.
- **Config additions** (`pkg/config`): Added `scan_interval` (default: 24h) and `restore_workers` (default: 4) with validation and tests.
- **DB extension** (`pkg/db`): Added `ListAllOffloadedFiles()` to support startup reconciliation.
- **Restore reuse** (`pkg/restore`): Exported `RestoreOne()` so the daemon's persistent worker pool can restore single files without duplicating logic.
- **Daemon core** (`pkg/daemon`):
  - **Lifecycle**: Context-based cancellation, signal handling, clean shutdown (stop ticker, close inotify, drain restore workers, close DB).
  - **Periodic scans**: Configurable ticker runs a combined scan that reuses existing `shrink.Run`, `scanner.ScanForRestore`, and `scanner.ScanAll`.
  - **Combined scan behavior**: Shrink/offload newly eligible files; detect sparse files missing `.offloaded` markers and enqueue restore jobs; register inotify watches on parent directories of `.offloaded` markers.
  - **Inotify watcher**: Uses `unix.InotifyInit1`/`InotifyAddWatch` with `unix.Poll` for shutdown-friendly event reading. Detects `IN_DELETE`/`IN_MOVED_FROM` on `.offloaded` markers and enqueues restore jobs.
  - **Restore queue**: Async in-memory queue with configurable worker pool. `inFlight` map prevents duplicate concurrent restores for the same path. Failed restores clear in-flight state for retry.
  - **DB reconciliation** (startup): Handles all 5 cases:
    1. Missing MP4 → remove DB row
    2. Restored MP4 (non-sparse, size matches) → remove DB row
    3. Still offloaded (sparse + marker exists) → do nothing
    4. Sparse, marker missing, but main marker still has file id → let normal scan handle it
    5. DB-only recovery (sparse, marker missing, main marker gone) → enqueue restore from DB metadata
  - **Credentials reload**: Each restore job resolves credentials via `credentials.FindForPath`, so credential changes are picked up between scans.
  - **Dry-run mode**: Reports planned actions without punching holes, creating/deleting markers, downloading, renaming, or writing DB changes.

## Tests added

- Daemon config parsing/defaults for `scan_interval` and `restore_workers`
- Restore queue deduplication and re-enqueue after completion
- `resolveRestoreJob` from marker file and DB fallback
- DB reconciliation cases: missing file, restored file, still offloaded, DB-only recovery, dry-run preservation
- Daemon start/stop lifecycle
- Combined scan minimum-age behavior (applies only to shrink, not restore)

## How it was tested

- `go test ./...` passes
- `CGO_ENABLED=0 go build ./cmd/media-offload` succeeds
- Manual CLI verification: `media-offload daemon --config ./testdata/config.yaml --dry-run` starts and reports planned actions

## Out of scope

Systemd unit packaging, web UI, PHP integration, cross-machine coordination, and file locking beyond safe local restore/offload operations.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@mmilitzer can click here to [continue refining the PR](https://app.all-hands.dev/conversations/27440bde-9c93-451f-885d-9ac428da4046)