### PR TITLE
Harden startup DB reconciliation (Issue #11)

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -694,7 +694,7 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	d.stopInotify()
 }
 
-func TestReconcileWatchesOffloadedFileWhenMarkerMissing(t *testing.T) {
+func TestReconcileRestoresOffloadedFileWhenMarkerMissing(t *testing.T) {
 	dir := t.TempDir()
 	setDir := filepath.Join(dir, "set1")
 	// Create marker initially so the file gets offloaded.
@@ -742,23 +742,81 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 
 	d := NewDaemon(cfg, false, database, nil)
 
-	// Start inotify manually.
-	if err := d.startInotify(); err != nil {
-		t.Skipf("inotify not available: %v", err)
+	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
+	d.reconcileRecord(rec)
+
+	// The .offloaded marker should have been removed.
+	if _, err := os.Stat(path + ".offloaded"); !os.IsNotExist(err) {
+		t.Error("expected .offloaded marker to be removed when main marker is missing")
 	}
+
+	// A restore job should have been enqueued.
+	d.inFlightMu.Lock()
+	inFlight := d.inFlight[path]
+	d.inFlightMu.Unlock()
+	if !inFlight {
+		t.Error("expected restore job to be enqueued when main marker is missing")
+	}
+}
+
+func TestReconcileRestoresOffloadedFileWhenMarkerHasNoFileID(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	// Create a marker that is valid but does not contain a file_id for this file.
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/other.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createSparseFile(t, path)
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	if err := database.UpsertOffloadedFile(path, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .offloaded marker to simulate an intentionally offloaded file.
+	if err := os.WriteFile(path+".offloaded", []byte("offloaded"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+		LockFile:        filepath.Join(t.TempDir(), "daemon.lock"),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
 
 	rec := db.OffloadedRecord{LocalPath: path, RemoteFileID: "remote-id", Autograph: 1, OriginalSize: 100}
 	d.reconcileRecord(rec)
 
-	// Verify the parent directory got watched.
-	d.watchesMu.Lock()
-	_, watched := d.watches[filepath.Dir(path)]
-	d.watchesMu.Unlock()
-	if !watched {
-		t.Error("expected parent dir to be watched during reconciliation of offloaded file")
+	// The .offloaded marker should have been removed.
+	if _, err := os.Stat(path + ".offloaded"); !os.IsNotExist(err) {
+		t.Error("expected .offloaded marker to be removed when main marker no longer contains file id")
 	}
 
-	d.stopInotify()
+	// A restore job should have been enqueued.
+	d.inFlightMu.Lock()
+	inFlight := d.inFlight[path]
+	d.inFlightMu.Unlock()
+	if !inFlight {
+		t.Error("expected restore job to be enqueued when main marker no longer contains file id")
+	}
 }
 
 func TestReconcileMarkerLookupInSubdirectory(t *testing.T) {

--- a/pkg/daemon/reconcile.go
+++ b/pkg/daemon/reconcile.go
@@ -64,21 +64,7 @@ func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
 		return
 	}
 
-	// File is sparse.
-	offloadedMarkerPath := path + ".offloaded"
-	_, offloadedMarkerErr := os.Stat(offloadedMarkerPath)
-	hasOffloadedMarker := offloadedMarkerErr == nil
-
-	if hasOffloadedMarker {
-		// Case 3: still intentionally offloaded.
-		// Register an inotify watch on the parent directory so we are notified
-		// when the .offloaded marker is deleted, even if the main marker file
-		// was removed and the normal scan no longer finds this folder.
-		_ = d.addInotifyWatch(filepath.Dir(path))
-		return
-	}
-
-	// .offloaded marker is missing. Walk upward to find the main marker file.
+	// File is sparse. Walk upward to find the main marker file first.
 	markerPath, markerDir := findMarkerForPath(path, d.cfg.MarkerFilename)
 	mInfo, err := marker.Parse(markerPath)
 	markerValid := err == nil && mInfo.Valid
@@ -89,12 +75,34 @@ func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {
 		_, markerHasFileID = mInfo.MatchFileID(relPath)
 	}
 
+	offloadedMarkerPath := path + ".offloaded"
+	_, offloadedMarkerErr := os.Stat(offloadedMarkerPath)
+	hasOffloadedMarker := offloadedMarkerErr == nil
+
 	if markerValid && markerHasFileID {
-		// Case 4: marker exists with file id. Normal scan will handle it.
+		// Case 3: marker exists with file id.
+		if hasOffloadedMarker {
+			// Still intentionally offloaded. Register an inotify watch.
+			_ = d.addInotifyWatch(filepath.Dir(path))
+		}
+		// If .offloaded is missing, normal scan will handle it.
 		return
 	}
 
-	// Case 5: DB-only recovery.
+	// Case 4 & 5: marker is missing, invalid, or no longer contains the file's
+	// remote file id. The set is no longer managed by our service.
+	if hasOffloadedMarker {
+		if d.dryRun {
+			log.Printf("dry-run DB reconcile: would remove .offloaded marker for %s", path)
+		} else {
+			if err := os.Remove(offloadedMarkerPath); err != nil {
+				log.Printf("DB reconcile: failed to remove .offloaded marker for %s: %v", path, err)
+			} else {
+				log.Printf("DB reconcile: removed .offloaded marker for %s", path)
+			}
+		}
+	}
+
 	if d.dryRun {
 		log.Printf("dry-run DB reconcile: would enqueue DB-only restore for %s", path)
 		return


### PR DESCRIPTION
## Summary

Implements Issue #11: hardens the daemon's startup DB reconciliation to restore files immediately when their main marker file is no longer valid, instead of merely registering an inotify watch.

## Changes

### 
- Restructured  to check the main marker file **before** deciding what to do with the  companion marker.
- When the main marker is missing, invalid, or no longer contains the file's remote file ID:
  - The  marker is now removed (or treated as logically removed in dry-run mode).
  - An immediate restore is enqueued using the DB metadata.
- When the main marker is valid and still contains the file ID, behavior is unchanged: register an inotify watch if  exists.

### 
- Updated  (formerly ) to assert the new behavior:  marker removal and restore job enqueueing.
- Added  to cover the case where the marker exists but no longer maps the file.

## Rationale

Once the main marker is gone, the set is no longer managed by our service, so the local file should be restored as soon as possible. Relying on future  deletion via DB state is brittle if the DB is later lost.

## Testing

- All existing tests pass.
- New tests verify  removal and restore enqueueing for both missing markers and markers that no longer contain the file ID.
- Verified ?   	github.com/mmilitzer/xvid-media-offload/cmd/media-offload	[no test files]
ok  	github.com/mmilitzer/xvid-media-offload/pkg/config	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/credentials	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/daemon	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/db	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/download	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/lockfile	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/marker	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/punch	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/restore	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/scanner	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/shrink	(cached)
ok  	github.com/mmilitzer/xvid-media-offload/pkg/sparse	(cached) passes.
- Verified static binary builds successfully with .

_This PR was created by an AI agent (OpenHands) on behalf of the user._