### PR TITLE
feat: configurable .offloaded marker file permissions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -26,7 +27,12 @@ type Config struct {
 	// DownloadTimeout is the global HTTP timeout for file downloads.
 	// When empty or zero, defaults to 6 hours.
 	DownloadTimeout Duration `yaml:"download_timeout"`
-	Verbose         bool     `yaml:"-"` // set from CLI flag
+	// MarkerFileMode controls the permissions of created .offloaded marker files.
+	// When empty or "same-as-source" (the default), markers inherit the
+	// permission bits of the source media file.  Any other value is parsed as
+	// an octal string (e.g. "0666") and applied literally.
+	MarkerFileMode string `yaml:"marker_file_mode"`
+	Verbose        bool   `yaml:"-"` // set from CLI flag
 }
 
 // Load reads and parses a YAML configuration file.
@@ -87,5 +93,53 @@ func (c *Config) Validate() error {
 	if c.DownloadTimeout.Duration() <= 0 {
 		c.DownloadTimeout = Duration(defaultDownloadTimeout)
 	}
+	if err := c.validateMarkerFileMode(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (c *Config) validateMarkerFileMode() error {
+	if c.MarkerFileMode == "" || c.MarkerFileMode == "same-as-source" {
+		return nil
+	}
+	u, err := strconv.ParseUint(c.MarkerFileMode, 8, 32)
+	if err != nil {
+		return fmt.Errorf("config validation failed: marker_file_mode must be \"same-as-source\" or a valid octal mode (e.g. \"0666\"): %w", err)
+	}
+	if u > 0777 {
+		return fmt.Errorf("config validation failed: marker_file_mode %q exceeds maximum permission bits 0777", c.MarkerFileMode)
+	}
+	return nil
+}
+
+// ResolveMarkerFileMode returns the file mode to use for an .offloaded marker
+// based on the source media file and the MarkerFileMode setting.
+func (c *Config) ResolveMarkerFileMode(sourcePath string) (os.FileMode, error) {
+	if c.MarkerFileMode == "" || c.MarkerFileMode == "same-as-source" {
+		fi, err := os.Stat(sourcePath)
+		if err != nil {
+			return 0, err
+		}
+		return fi.Mode() & os.ModePerm, nil
+	}
+	u, err := strconv.ParseUint(c.MarkerFileMode, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid marker_file_mode %q: %w", c.MarkerFileMode, err)
+	}
+	return os.FileMode(u), nil
+}
+
+// CreateOffloadedMarker writes an .offloaded marker file with permissions
+// determined by the configuration.  The mode is applied explicitly with
+// Chmod so that umask does not interfere.
+func (c *Config) CreateOffloadedMarker(sourcePath, markerPath string, content []byte) error {
+	mode, err := c.ResolveMarkerFileMode(sourcePath)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(markerPath, content, mode); err != nil {
+		return err
+	}
+	return os.Chmod(markerPath, mode)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -306,3 +306,164 @@ restore_workers: 8
 		t.Errorf("expected restore_workers 8, got %d", cfg.RestoreWorkers)
 	}
 }
+
+func TestValidateMarkerFileModeDefault(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MarkerFileMode != "" {
+		t.Errorf("expected empty marker_file_mode by default, got %s", cfg.MarkerFileMode)
+	}
+}
+
+func TestValidateMarkerFileModeExplicit(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		MarkerFileMode:  "0666",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateMarkerFileModeSameAsSource(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		MarkerFileMode:  "same-as-source",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateMarkerFileModeInvalidOctal(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		MarkerFileMode:  "not-octal",
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for invalid marker_file_mode")
+	}
+}
+
+func TestValidateMarkerFileModeTooLarge(t *testing.T) {
+	cfg := &Config{
+		ScanRoots:       []string{"/tmp"},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		MarkerFileMode:  "07777",
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for marker_file_mode exceeding 0777")
+	}
+}
+
+func TestResolveMarkerFileModeSameAsSource(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "video.mp4")
+	if err := os.WriteFile(sourcePath, []byte("content"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{MarkerFileMode: "same-as-source"}
+	mode, err := cfg.ResolveMarkerFileMode(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != 0750 {
+		t.Errorf("expected mode 0750, got %04o", mode)
+	}
+}
+
+func TestResolveMarkerFileModeEmptyDefaultsToSameAsSource(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "video.mp4")
+	if err := os.WriteFile(sourcePath, []byte("content"), 0640); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{MarkerFileMode: ""}
+	mode, err := cfg.ResolveMarkerFileMode(sourcePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != 0640 {
+		t.Errorf("expected mode 0640, got %04o", mode)
+	}
+}
+
+func TestResolveMarkerFileModeExplicit(t *testing.T) {
+	cfg := &Config{MarkerFileMode: "0666"}
+	mode, err := cfg.ResolveMarkerFileMode("/nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != 0666 {
+		t.Errorf("expected mode 0666, got %04o", mode)
+	}
+}
+
+func TestCreateOffloadedMarkerRespectsMode(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "video.mp4")
+	markerPath := filepath.Join(dir, "video.mp4.offloaded")
+	if err := os.WriteFile(sourcePath, []byte("content"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{MarkerFileMode: "same-as-source"}
+	if err := cfg.CreateOffloadedMarker(sourcePath, markerPath, []byte("marker")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fi, err := os.Stat(markerPath)
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0750 {
+		t.Errorf("expected marker mode 0750, got %04o", fi.Mode().Perm())
+	}
+}
+
+func TestCreateOffloadedMarkerExplicitMode(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "video.mp4")
+	markerPath := filepath.Join(dir, "video.mp4.offloaded")
+	if err := os.WriteFile(sourcePath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{MarkerFileMode: "0666"}
+	if err := cfg.CreateOffloadedMarker(sourcePath, markerPath, []byte("marker")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fi, err := os.Stat(markerPath)
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0666 {
+		t.Errorf("expected marker mode 0666, got %04o", fi.Mode().Perm())
+	}
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -210,7 +210,7 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 	}
 	if !enough {
 		// Recreate .offloaded marker and skip.
-		err = os.WriteFile(f.Path+".offloaded", []byte(offloadedMarkerContent), 0644)
+		err = cfg.CreateOffloadedMarker(f.Path, f.Path+".offloaded", []byte(offloadedMarkerContent))
 		if err != nil {
 			return RestoreInfo{}, fmt.Errorf("not enough space (%d bytes available) and failed to recreate marker: %w", avail, err)
 		}

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -345,6 +345,144 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	}
 }
 
+func TestRestoreRecreatesMarkerWithSourcePermissions(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createFile(t, path, "old content")
+	if err := os.Chmod(path, 0750); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-720 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	origDiskCheck := checkDiskSpace
+	checkDiskSpace = func(p string, n int64) (bool, int64, error) {
+		return false, 0, nil
+	}
+	defer func() { checkDiskSpace = origDiskCheck }()
+
+	res, err := Run(cfg, false, 1, nil, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedNoSpace != 1 {
+		t.Errorf("expected 1 skipped no space, got %d", res.SkippedNoSpace)
+	}
+
+	fi, err := os.Stat(path + ".offloaded")
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0750 {
+		t.Errorf("expected marker mode 0750, got %04o", fi.Mode().Perm())
+	}
+}
+
+func TestRestoreRecreatesMarkerWithExplicitMode(t *testing.T) {
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	createOldFile(t, path)
+
+	createCredentialFile(t, dir, "test-client", "dGVzdC1zZWNyZXQ=")
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		MarkerFileMode:  "0666",
+	}
+
+	origScan := scanForRestore
+	scanForRestore = func(c *config.Config) (*scanner.ScanResult, error) {
+		return &scanner.ScanResult{
+			Files: []scanner.FileInfo{
+				{
+					Path:               path,
+					RelPath:            "set1/4k/video.mp4",
+					Size:               100,
+					RemoteID:           "669872d3d3586a56f9a3dfad",
+					Autograph:          1,
+					MarkerPath:         filepath.Join(setDir, ".htaccess"),
+					ScanRoot:           dir,
+					IsSparse:           true,
+					HasOffloadedMarker: false,
+				},
+			},
+		}, nil
+	}
+	defer func() { scanForRestore = origScan }()
+
+	origDiskCheck := checkDiskSpace
+	checkDiskSpace = func(p string, n int64) (bool, int64, error) {
+		return false, 0, nil
+	}
+	defer func() { checkDiskSpace = origDiskCheck }()
+
+	res, err := Run(cfg, false, 1, nil, &mockDownloader{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SkippedNoSpace != 1 {
+		t.Errorf("expected 1 skipped no space, got %d", res.SkippedNoSpace)
+	}
+
+	fi, err := os.Stat(path + ".offloaded")
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0666 {
+		t.Errorf("expected marker mode 0666, got %04o", fi.Mode().Perm())
+	}
+}
+
 func TestRestoreMinimumAgeIgnored(t *testing.T) {
 	dir := t.TempDir()
 	setDir := filepath.Join(dir, "set1")

--- a/pkg/shrink/shrink.go
+++ b/pkg/shrink/shrink.go
@@ -245,7 +245,7 @@ func processCandidates(cfg *config.Config, dryRun bool, database *db.DB, candida
 
 		// Create .offloaded marker.
 		markerPath := c.Path + ".offloaded"
-		err = os.WriteFile(markerPath, []byte(offloadedMarkerContent), 0644)
+		err = cfg.CreateOffloadedMarker(c.Path, markerPath, []byte(offloadedMarkerContent))
 		if err != nil {
 			res.Errors++
 			msg := fmt.Sprintf("%s: failed to create offloaded marker: %v", c.Path, err)

--- a/pkg/shrink/shrink_test.go
+++ b/pkg/shrink/shrink_test.go
@@ -375,6 +375,123 @@ func createOldFile(t *testing.T, path string) {
 	}
 }
 
+func TestShrinkApplyMarkerPermissionsSameAsSource(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run apply-mode shrink tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0750)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 4*1024*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	oldTime := time.Now().Add(-720 * time.Hour)
+	os.Chtimes(path, oldTime, oldTime)
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1024 * 1024,
+	}
+
+	res, err := Run(cfg, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Offloaded) != 1 {
+		t.Fatalf("expected 1 offloaded file, got %d", len(res.Offloaded))
+	}
+
+	fi, err := os.Stat(path + ".offloaded")
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0750 {
+		t.Errorf("expected marker mode 0750, got %04o", fi.Mode().Perm())
+	}
+}
+
+func TestShrinkApplyMarkerPermissionsExplicitMode(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run apply-mode shrink tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 4*1024*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	oldTime := time.Now().Add(-720 * time.Hour)
+	os.Chtimes(path, oldTime, oldTime)
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1024 * 1024,
+		MarkerFileMode:  "0666",
+	}
+
+	res, err := Run(cfg, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Offloaded) != 1 {
+		t.Fatalf("expected 1 offloaded file, got %d", len(res.Offloaded))
+	}
+
+	fi, err := os.Stat(path + ".offloaded")
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if fi.Mode().Perm() != 0666 {
+		t.Errorf("expected marker mode 0666, got %04o", fi.Mode().Perm())
+	}
+}
+
 func TestRunFromAllProducesSameDryRunResults(t *testing.T) {
 	dir := t.TempDir()
 	setDir := filepath.Join(dir, "set1")


### PR DESCRIPTION
## Summary

This PR fixes `.offloaded` marker permissions so they work correctly in group-based access environments (e.g. FTP users).

## Changes

- **Config**: Added `marker_file_mode` option. Defaults to `same-as-source` when not explicitly configured.
- **Behavior**: When creating `filename.mp4.offloaded`, permissions now match the source MP4 file's mode bits.
- **Override**: Supports an explicit octal mode string like `marker_file_mode: "0666"`.
- **Umask safety**: After `os.WriteFile`, an explicit `os.Chmod` is called so the intended mode is applied regardless of the process umask.
- **Coverage**: Added tests verifying marker file permissions for both the shrink (offload) and restore paths.

## Example configuration

```yaml
# Inherit permissions from the source MP4 (default)
marker_file_mode: "same-as-source"

# Or set an explicit mode
marker_file_mode: "0666"
```

## Tests

- `pkg/config` — validation and resolution of `marker_file_mode`
- `pkg/shrink` — apply-mode shrink creates markers with correct permissions
- `pkg/restore` — markers recreated during "no disk space" restore respect the configured mode

All existing tests continue to pass.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@mmilitzer can click here to [continue refining the PR](https://app.all-hands.dev/conversations/610d9395-9719-4555-bce9-a755170953ff)