### PR TITLE
Preserve original MP4 mtime/atime during offload

### DIFF
--- a/pkg/shrink/shrink.go
+++ b/pkg/shrink/shrink.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mmilitzer/xvid-media-offload/pkg/punch"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
 	"github.com/mmilitzer/xvid-media-offload/pkg/sparse"
+	"golang.org/x/sys/unix"
 )
 
 // OffloadInfo holds details about a successfully offloaded file.
@@ -119,6 +120,16 @@ func RunFromAll(cfg *config.Config, dryRun bool, database *db.DB, all *scanner.S
 	return processCandidates(cfg, dryRun, database, candidates, res)
 }
 
+func getFileTimestamps(path string) (atime, mtime time.Time, err error) {
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	atime = time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+	mtime = time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
+	return atime, mtime, nil
+}
+
 func processCandidates(cfg *config.Config, dryRun bool, database *db.DB, candidates []scanner.Candidate, res *Result) (*Result, error) {
 	for _, c := range candidates {
 		// Skip files that are too small.
@@ -190,6 +201,18 @@ func processCandidates(cfg *config.Config, dryRun bool, database *db.DB, candida
 			continue
 		}
 
+		// Store original timestamps before hole punching.
+		origAtime, origMtime, err := getFileTimestamps(c.Path)
+		if err != nil {
+			res.Errors++
+			msg := fmt.Sprintf("%s: stat before punch failed: %v", c.Path, err)
+			res.ErrorDetails = append(res.ErrorDetails, msg)
+			if cfg.Verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+			continue
+		}
+
 		err = punch.PunchHole(c.Path, cfg.KeepPrefixBytes)
 		if err != nil {
 			res.Errors++
@@ -254,6 +277,16 @@ func processCandidates(cfg *config.Config, dryRun bool, database *db.DB, candida
 				fmt.Fprintln(os.Stderr, msg)
 			}
 			continue
+		}
+
+		// Restore original timestamps so the MP4 keeps its original modified time.
+		if err := os.Chtimes(c.Path, origAtime, origMtime); err != nil {
+			res.Errors++
+			msg := fmt.Sprintf("%s: failed to restore original timestamps: %v", c.Path, err)
+			res.ErrorDetails = append(res.ErrorDetails, msg)
+			if cfg.Verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			}
 		}
 
 		// Write DB record if configured.

--- a/pkg/shrink/shrink_test.go
+++ b/pkg/shrink/shrink_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mmilitzer/xvid-media-offload/pkg/config"
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
+	"golang.org/x/sys/unix"
 )
 
 func TestShrinkDryRunDoesNotModify(t *testing.T) {
@@ -544,5 +545,110 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	}
 	if resFromAll.SkippedMissingRemote != resRun.SkippedMissingRemote {
 		t.Errorf("SkippedMissingRemote mismatch: %d vs %d", resFromAll.SkippedMissingRemote, resRun.SkippedMissingRemote)
+	}
+}
+
+func TestShrinkApplyPreservesMtime(t *testing.T) {
+	if os.Getenv("RUN_HOLE_PUNCH_TESTS") != "1" {
+		t.Skip("Set RUN_HOLE_PUNCH_TESTS=1 to run apply-mode shrink tests")
+	}
+
+	dir := t.TempDir()
+	setDir := filepath.Join(dir, "set1")
+	createMarker(t, setDir, `#Xvid AutoGraph content protection system.
+RewriteEngine on
+RewriteRule "^4k/video.mp4" - [F,L,NC]
+#autograph=1
+#file_id=669872d3d3586a56f9a3dfad
+`)
+
+	path := filepath.Join(setDir, "4k", "video.mp4")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 4*1024*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// Set an old, specific mtime/atime.
+	oldTime := time.Date(2020, 1, 15, 10, 30, 0, 0, time.UTC)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{dir},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1024 * 1024,
+	}
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	beforeOffload := time.Now()
+	res, err := Run(cfg, false, database)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Offloaded) != 1 {
+		t.Fatalf("expected 1 offloaded file, got %d", len(res.Offloaded))
+	}
+
+	// Verify MP4 mtime is preserved.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("unexpected error stat mp4: %v", err)
+	}
+	if !fi.ModTime().Equal(oldTime) {
+		t.Errorf("expected MP4 mtime %v, got %v", oldTime, fi.ModTime())
+	}
+
+	// Verify MP4 atime is preserved.
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		t.Fatalf("unexpected error unix stat mp4: %v", err)
+	}
+	atime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+	if !atime.Equal(oldTime) {
+		t.Errorf("expected MP4 atime %v, got %v", oldTime, atime)
+	}
+
+	// Verify .offloaded marker has newer mtime.
+	mfi, err := os.Stat(path + ".offloaded")
+	if err != nil {
+		t.Fatalf("unexpected error stat marker: %v", err)
+	}
+	if !mfi.ModTime().After(oldTime) {
+		t.Errorf("expected marker mtime after %v, got %v", oldTime, mfi.ModTime())
+	}
+	if !mfi.ModTime().After(beforeOffload.Add(-1 * time.Second)) {
+		t.Errorf("expected marker mtime around offload time, got %v (before %v)", mfi.ModTime(), beforeOffload)
+	}
+
+	// Verify DB offloaded_at records offload time.
+	_, _, _, offloadedAt, err := database.GetOffloadedFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error getting db record: %v", err)
+	}
+	if !offloadedAt.After(oldTime) {
+		t.Errorf("expected DB offloaded_at after %v, got %v", oldTime, offloadedAt)
+	}
+	if !offloadedAt.After(beforeOffload.Add(-1 * time.Second)) {
+		t.Errorf("expected DB offloaded_at around offload time, got %v (before %v)", offloadedAt, beforeOffload)
 	}
 }


### PR DESCRIPTION
This PR ensures that the original modification and access times of MP4 files are preserved during the offload process.

### Changes
- **Before hole punching**: `getFileTimestamps()` uses `unix.Stat` to capture the MP4's original `atime` and `mtime`.
- **After successful hole punching and marker creation**: `os.Chtimes` (which uses `utimensat` on Linux) restores both timestamps so the MP4 keeps its original modified time.
- **`.offloaded` marker**: Continues to use its natural creation/modified time from when the offload happened.

### Tests Added
`TestShrinkApplyPreservesMtime` verifies:
1. The MP4 `mtime` is unchanged after shrink/offload.
2. The MP4 `atime` is unchanged after shrink/offload.
3. The `.offloaded` marker has a newer/current `mtime`.
4. The DB `offloaded_at` still records the offload time.

> _This pull request was created by an AI agent (OpenHands) on behalf of the user._