### PR TITLE
Add version/build information to binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,21 @@ jobs:
         run: go vet ./...
 
       - name: Build binary
-        run: CGO_ENABLED=0 go build -o media-offload ./cmd/media-offload
+        run: |
+          mkdir -p dist
+          VERSION="v0.1.${{ github.run_number }}"
+          COMMIT="${GITHUB_SHA::7}"
+          BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+            -ldflags "\
+              -X 'github.com/mmilitzer/xvid-media-offload/pkg/version.Version=${VERSION}' \
+              -X 'github.com/mmilitzer/xvid-media-offload/pkg/version.Commit=${COMMIT}' \
+              -X 'github.com/mmilitzer/xvid-media-offload/pkg/version.BuiltAt=${BUILT_AT}'" \
+            -o dist/media-offload ./cmd/media-offload
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: media-offload-linux-amd64
-          path: media-offload
+          path: dist/media-offload

--- a/cmd/media-offload/main.go
+++ b/cmd/media-offload/main.go
@@ -18,17 +18,24 @@ import (
 	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
 	"github.com/mmilitzer/xvid-media-offload/pkg/shrink"
+	"github.com/mmilitzer/xvid-media-offload/pkg/version"
 )
 
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: media-offload <command> [options]")
 		fmt.Fprintln(os.Stderr, "Commands:")
-		fmt.Fprintln(os.Stderr, "  scan    Scan for offload candidates")
-		fmt.Fprintln(os.Stderr, "  shrink  Offload eligible files by punching holes")
-		fmt.Fprintln(os.Stderr, "  restore Restore offloaded files from remote storage")
-		fmt.Fprintln(os.Stderr, "  daemon  Run continuous daemon with periodic scans and inotify")
+		fmt.Fprintln(os.Stderr, "  scan     Scan for offload candidates")
+		fmt.Fprintln(os.Stderr, "  shrink   Offload eligible files by punching holes")
+		fmt.Fprintln(os.Stderr, "  restore  Restore offloaded files from remote storage")
+		fmt.Fprintln(os.Stderr, "  daemon   Run continuous daemon with periodic scans and inotify")
+		fmt.Fprintln(os.Stderr, "  version  Print version information")
 		os.Exit(1)
+	}
+
+	if os.Args[1] == "--version" || os.Args[1] == "-version" || os.Args[1] == "version" {
+		printVersion()
+		os.Exit(0)
 	}
 
 	command := os.Args[1]
@@ -45,6 +52,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
 		os.Exit(1)
 	}
+}
+
+func printVersion() {
+	fmt.Printf("media-offload %s\n", version.Version)
+	fmt.Printf("commit: %s\n", version.Commit)
+	fmt.Printf("built: %s\n", version.BuiltAt)
 }
 
 func runScan(args []string) int {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mmilitzer/xvid-media-offload/pkg/restore"
 	"github.com/mmilitzer/xvid-media-offload/pkg/scanner"
 	"github.com/mmilitzer/xvid-media-offload/pkg/shrink"
+	"github.com/mmilitzer/xvid-media-offload/pkg/version"
 )
 
 // Daemon runs the media-offload service in continuous mode.
@@ -104,7 +105,7 @@ func (d *Daemon) Start() error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
-	log.Println("daemon starting")
+	log.Printf("daemon starting — %s", version.String())
 
 	// Start restore workers FIRST so DB reconciliation and scans can enqueue.
 	for i := 0; i < d.cfg.RestoreWorkers; i++ {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import "fmt"
+
+var (
+	Version = "dev"
+	Commit  = "unknown"
+	BuiltAt = "unknown"
+)
+
+func String() string {
+	return fmt.Sprintf("%s (%s, built %s)", Version, Commit, BuiltAt)
+}


### PR DESCRIPTION
This PR adds version, commit SHA, and build date metadata to the binary.

### Changes
- **New `pkg/version` package** with `Version`, `Commit`, and `BuiltAt` variables (defaults: `dev`, `unknown`, `unknown`).
- **CLI integration**: `media-offload version` and `media-offload --version` print:
  ```
  media-offload v0.1.123
  commit: abcdef1
  built: 2026-05-06T12:34:56Z
  ```
- **Daemon startup logging**: logs the compact version string once at startup.
- **CI workflow updated**: GitHub Actions now injects version metadata at build time via `ldflags`:
  - `Version` = `v0.1.${{ github.run_number }}`
  - `Commit` = first 7 chars of `GITHUB_SHA`
  - `BuiltAt` = UTC ISO-8601 timestamp
- **Local builds** continue to work and show sensible defaults.

### Notes
This message was created by an AI agent (OpenHands) on behalf of the user.

@mmilitzer can click here to [continue refining the PR](https://app.all-hands.dev/conversations/791978b6-e177-4831-8972-ee066307247c)