### PR TITLE
fix(daemon): reconcileDB only acts on records inside configured scan_roots

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -870,6 +870,198 @@ RewriteRule "^4k/video.mp4" - [F,L,NC]
 	}
 }
 
+func TestPathUnderScanRoots(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		roots  []string
+		want   bool
+	}{
+		{
+			name:  "path inside scan root",
+			path:  "/site/content/video.mp4",
+			roots: []string{"/site/content"},
+			want:  true,
+		},
+		{
+			name:  "path outside scan root",
+			path:  "/other/video.mp4",
+			roots: []string{"/site/content"},
+			want:  false,
+		},
+		{
+			name:  "sibling path prefix does not match",
+			path:  "/site/content2/video.mp4",
+			roots: []string{"/site/content"},
+			want:  false,
+		},
+		{
+			name:  "exact scan root path",
+			path:  "/site/content",
+			roots: []string{"/site/content"},
+			want:  true,
+		},
+		{
+			name:  "parent path does not match",
+			path:  "/site",
+			roots: []string{"/site/content"},
+			want:  false,
+		},
+		{
+			name:  "multiple roots second matches",
+			path:  "/site/b/video.mp4",
+			roots: []string{"/site/a", "/site/b"},
+			want:  true,
+		},
+		{
+			name:  "trailing slash in root",
+			path:  "/site/content/video.mp4",
+			roots: []string{"/site/content/"},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathUnderScanRoots(tt.path, tt.roots)
+			if got != tt.want {
+				t.Errorf("pathUnderScanRoots(%q, %v) = %v, want %v", tt.path, tt.roots, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileDBSkipsPathsOutsideScanRoots(t *testing.T) {
+	dir := t.TempDir()
+	scanRoot := filepath.Join(dir, "content")
+	outsideDir := filepath.Join(dir, "other")
+	siblingDir := filepath.Join(dir, "content2")
+
+	for _, d := range []string{scanRoot, outsideDir, siblingDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	insidePath := filepath.Join(scanRoot, "video.mp4")
+	outsidePath := filepath.Join(outsideDir, "video.mp4")
+	siblingPath := filepath.Join(siblingDir, "video.mp4")
+
+	// Insert records for all three files (none exist on disk).
+	for _, p := range []string{insidePath, outsidePath, siblingPath} {
+		if err := database.UpsertOffloadedFile(p, "remote-id", 1, 100, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{scanRoot},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	if err := d.reconcileDB(); err != nil {
+		t.Fatalf("reconcileDB failed: %v", err)
+	}
+
+	// Inside path: file is missing, so reconcileRecord should delete the DB row.
+	_, _, _, _, err = database.GetOffloadedFile(insidePath)
+	if err == nil {
+		t.Error("expected DB record for inside path to be removed because file is missing")
+	}
+
+	// Outside path: should be skipped, DB row must remain.
+	_, _, _, _, err = database.GetOffloadedFile(outsidePath)
+	if err != nil {
+		t.Errorf("expected DB record for outside path to be preserved, got error: %v", err)
+	}
+
+	// Sibling path: should be skipped, DB row must remain.
+	_, _, _, _, err = database.GetOffloadedFile(siblingPath)
+	if err != nil {
+		t.Errorf("expected DB record for sibling path to be preserved, got error: %v", err)
+	}
+
+	// No restore jobs should have been enqueued for outside or sibling paths.
+	d.inFlightMu.Lock()
+	if d.inFlight[outsidePath] {
+		t.Error("expected no restore job for outside path")
+	}
+	if d.inFlight[siblingPath] {
+		t.Error("expected no restore job for sibling path")
+	}
+	d.inFlightMu.Unlock()
+}
+
+func TestReconcileDBPreservesOffloadedMarkerOutsideScanRoots(t *testing.T) {
+	dir := t.TempDir()
+	scanRoot := filepath.Join(dir, "content")
+	siblingDir := filepath.Join(dir, "content2")
+
+	for _, d := range []string{scanRoot, siblingDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("unexpected error opening db: %v", err)
+	}
+	defer database.Close()
+
+	siblingPath := filepath.Join(siblingDir, "video.mp4")
+	createSparseFile(t, siblingPath)
+
+	// Create .offloaded marker.
+	if err := os.WriteFile(siblingPath+".offloaded", []byte("offloaded"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := database.UpsertOffloadedFile(siblingPath, "remote-id", 1, 100, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ScanRoots:       []string{scanRoot},
+		CandidateGlobs:  []string{"**/*.mp4"},
+		MarkerFilename:  ".htaccess",
+		MinimumAge:      config.Duration(1 * time.Hour),
+		KeepPrefixBytes: 1,
+		RestoreWorkers:  1,
+		ScanInterval:    config.Duration(24 * time.Hour),
+	}
+
+	d := NewDaemon(cfg, false, database, nil)
+	if err := d.reconcileDB(); err != nil {
+		t.Fatalf("reconcileDB failed: %v", err)
+	}
+
+	// The .offloaded marker must NOT be removed.
+	if _, err := os.Stat(siblingPath + ".offloaded"); os.IsNotExist(err) {
+		t.Error("expected .offloaded marker to be preserved for path outside scan_roots")
+	}
+
+	// DB row must also remain.
+	_, _, _, _, err = database.GetOffloadedFile(siblingPath)
+	if err != nil {
+		t.Errorf("expected DB record to be preserved, got error: %v", err)
+	}
+}
+
 func createCredentialFile(t *testing.T, dir, clientID, clientSecret string) {
 	t.Helper()
 	content := fmt.Sprintf("[xvid]\nAPP_CLIENT_ID = \"%s\"\nAPP_CLIENT_SECRET = \"%s\"\n", clientID, clientSecret)

--- a/pkg/daemon/reconcile.go
+++ b/pkg/daemon/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mmilitzer/xvid-media-offload/pkg/db"
 	"github.com/mmilitzer/xvid-media-offload/pkg/marker"
@@ -18,10 +19,42 @@ func (d *Daemon) reconcileDB() error {
 	}
 
 	for _, rec := range records {
+		if !pathUnderScanRoots(rec.LocalPath, d.cfg.ScanRoots) {
+			log.Printf("DB reconcile: skipping %s because it is outside active scan_roots", rec.LocalPath)
+			continue
+		}
 		d.reconcileRecord(rec)
 	}
 
 	return nil
+}
+
+// pathUnderScanRoots reports whether path is contained within any of the
+// configured scan roots using safe path comparison (not a naive string prefix
+// check). Both paths are cleaned and made absolute before comparison.
+func pathUnderScanRoots(path string, roots []string) bool {
+	cleanPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+
+	for _, root := range roots {
+		cleanRoot, err := filepath.Abs(filepath.Clean(root))
+		if err != nil {
+			continue
+		}
+
+		rel, err := filepath.Rel(cleanRoot, cleanPath)
+		if err != nil {
+			continue
+		}
+
+		if rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (d *Daemon) reconcileRecord(rec db.OffloadedRecord) {


### PR DESCRIPTION
This PR fixes a bug where `reconcileDB()` would load **all** DB rows and reconcile every record, even if the file path was outside the current config's `scan_roots`. This could cause stale DB rows from old configurations to trigger restore actions or inotify watches outside the currently managed tree.

## Changes

- **Added `pathUnderScanRoots()` helper** in `pkg/daemon/reconcile.go` that uses safe path containment logic (`filepath.Rel`) instead of a naive string prefix check. Both paths are cleaned and made absolute before comparison.
- **Filtered DB records in `reconcileDB()`** before calling `reconcileRecord()`; records whose `local_path` is outside any active `scan_root` are now skipped with a log message.
- **Preserved skipped DB rows** — they are not automatically deleted, so they may become relevant again if the config is changed back.
- **Added comprehensive tests:**
  1. `TestPathUnderScanRoots` — unit tests for the helper covering inside, outside, exact match, parent path, multiple roots, and trailing slash cases.
  2. `TestReconcileDBSkipsPathsOutsideScanRoots` — integration test verifying that an inside-path record is reconciled normally (missing file → DB row deleted), while outside-path and sibling-prefix records are ignored.
  3. `TestReconcileDBPreservesOffloadedMarkerOutsideScanRoots` — verifies that `.offloaded` markers and DB rows are **not** removed for files outside active scan roots.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| DB row inside `scan_root` | Reconciled | Reconciled (no change) |
| DB row outside `scan_root` | Could delete files, remove markers, enqueue restore, register watches | Skipped, logged, DB row preserved |
| Sibling path (e.g. `/site/content2` vs `/site/content`) | Could falsely match via string prefix | Correctly rejected by `filepath.Rel` logic |

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@mmilitzer can click here to [continue refining the PR](https://app.all-hands.dev/conversations/68e48ffd-0801-4075-9ba9-3ffa074e6ca3)