### PR TITLE
Add owner mismatch to reports and decouple restore from ownership_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ systemctl restart media-offload
 
 ## Ownership policy
 
-The `ownership_policy` setting controls how the tool handles MP4 files that are not owned by the user running the daemon. The default is `require-daemon-owner`, which is the safest and most predictable option.
+The `ownership_policy` setting controls **offload/shrink eligibility** and the offload strategy for MP4 files that are not owned by the user running the daemon. It does **not** affect restore behavior — restore always uses best-effort metadata preservation regardless of the policy (see [Restore behavior](#restore-behavior) below).
+
+The default is `require-daemon-owner`, which is the safest and most predictable option.
 
 ### `require-daemon-owner` (default)
 
@@ -233,7 +235,7 @@ Only MP4 files owned by the current effective UID are candidates for offload. Fi
 
 ### `allow-owner-mismatch`
 
-MP4 files not owned by the daemon user may still be offloaded if the process has sufficient write access. The existing hole-punch strategy is used, but mtime restoration failures are logged rather than treated as fatal errors. On restore, the tool attempts to `chown`/`chgrp` the file back to its original owner; if that fails, the error is logged but the restore still succeeds.
+MP4 files not owned by the daemon user may still be offloaded if the process has sufficient write access. The existing hole-punch strategy is used, but mtime restoration failures are logged rather than treated as fatal errors.
 
 This mode is useful when the daemon must run as a different user and you have granted `CAP_FOWNER` or similar privileges, but it accepts that owner and timestamps may not be fully preserved without those capabilities.
 
@@ -244,6 +246,16 @@ MP4 files not owned by the daemon user are replaced with a new sparse file owned
 If a file is already owned by the daemon user, the normal hole-punch strategy is still used.
 
 **Warning:** The replace strategy changes file ownership. Make sure this is compatible with your CMS, FTP/SFTP access, and backup tools before enabling it.
+
+### Restore behavior
+
+Restore is independent of `ownership_policy`. When a sparse file needs to be restored, the tool always attempts it as long as the remote ID is known, credentials are available, and there is enough disk space. Before replacing the sparse file, the tool captures its current uid/gid and mode, then applies them to the restored file on a best-effort basis:
+
+- `chmod` is applied to the temp file; failure is fatal (the restore is aborted).
+- `chown(-1, gid)` is attempted to preserve the group; failure is a warning, not a blocker.
+- `chown(uid, -1)` is attempted to preserve the owner; failure is a warning, not a blocker.
+
+If uid/gid preservation fails (e.g. the daemon lacks `CAP_CHOWN`), the restored file will be owned by the daemon user instead.
 
 ---
 

--- a/cmd/media-offload/main.go
+++ b/cmd/media-offload/main.go
@@ -140,6 +140,7 @@ func printScanReport(res *scanner.Result, verbose bool) {
 	fmt.Printf("total candidate files size: %d\n", res.TotalCandidateSize)
 	fmt.Printf("skipped already offloaded:  %d\n", res.SkippedOffloaded)
 	fmt.Printf("skipped too young:          %d\n", res.SkippedTooYoung)
+	fmt.Printf("skipped owner mismatch:     %d\n", res.SkippedOwnerMismatch)
 	fmt.Printf("skipped file not found:     %d\n", res.SkippedMissingRemote)
 	fmt.Printf("errors:                     %d\n", res.Errors)
 
@@ -307,6 +308,7 @@ func printShrinkReport(res *shrink.Result, dryRun bool, verbose bool) {
 	fmt.Printf("skipped too young:          %d\n", res.SkippedTooYoung)
 	fmt.Printf("skipped too small:          %d\n", res.SkippedTooSmall)
 	fmt.Printf("skipped no autograph:       %d\n", res.SkippedNoAutograph)
+	fmt.Printf("skipped owner mismatch:     %d\n", res.SkippedOwnerMismatch)
 	fmt.Printf("skipped file not found:     %d\n", res.SkippedMissingRemote)
 	fmt.Printf("errors:                     %d\n", res.Errors)
 	fmt.Printf("total logical files size:   %d\n", res.TotalCandidateSize)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,8 +39,10 @@ type Config struct {
 	// permission bits of the source media file.  Any other value is parsed as
 	// an octal string (e.g. "0666") and applied literally.
 	MarkerFileMode string `yaml:"marker_file_mode"`
-	// OwnershipPolicy controls how the tool handles MP4 files that are not
-	// owned by the user running the daemon.
+	// OwnershipPolicy controls offload/shrink eligibility and the offload
+	// strategy for MP4 files that are not owned by the daemon user.
+	// Restore is independent of this setting and always uses best-effort
+	// metadata preservation.
 	//   require-daemon-owner           - only offload files owned by the daemon user (default)
 	//   allow-owner-mismatch           - allow offloading non-owned files with best-effort preservation
 	//   replace-with-daemon-owned-sparse-copy - replace non-owned files with a daemon-owned sparse copy

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -310,50 +310,35 @@ func restoreOne(ctx context.Context, job Job, cfg *config.Config, database *db.D
 		return RestoreInfo{}, fmt.Errorf("chmod temp file: %w", chmodErr)
 	}
 
-	// Attempt to preserve the captured uid/gid on the temp file for all
-	// ownership policies.  We split the chown into separate group and owner
-	// attempts so that partial preservation is possible (e.g. a non-root
-	// daemon can often change the group but not the owner).
+	// Attempt to preserve the captured uid/gid on the temp file using
+	// best-effort metadata preservation.  ownership_policy controls only
+	// offload/shrink eligibility; restore always tries to preserve the
+	// original owner and group.  We split the chown into separate group and
+	// owner attempts so that partial preservation is possible (e.g. a
+	// non-root daemon can often change the group but not the owner).
+	// Failures to preserve uid/gid are logged as warnings but never block
+	// the restore — the restored file may end up owned by the daemon user.
 	var tempStat unix.Stat_t
 	if statErr := unix.Stat(tempPath, &tempStat); statErr != nil {
-		msg := fmt.Sprintf("%s: failed to stat temp file for ownership check: %v", f.Path, statErr)
-		if cfg.OwnershipPolicy == config.OwnershipPolicyRequireDaemonOwner {
-			os.Remove(tempPath)
-			return RestoreInfo{}, fmt.Errorf("%s", msg)
-		}
+		msg := fmt.Sprintf("%s: warning: failed to stat temp file for ownership check: %v", f.Path, statErr)
 		if cfg.Verbose {
 			fmt.Fprintln(os.Stderr, msg)
 		}
 	} else {
 		curUID := int(tempStat.Uid)
 		curGID := int(tempStat.Gid)
-		strictMode := cfg.OwnershipPolicy == config.OwnershipPolicyRequireDaemonOwner
 
 		// Attempt group preservation first: chown(-1, origGID).
 		if curGID != origGID {
 			if chownErr := os.Chown(tempPath, -1, origGID); chownErr != nil {
-				msg := fmt.Sprintf("%s: failed to restore original group (%d→%d): %v", f.Path, curGID, origGID, chownErr)
-				if strictMode {
-					os.Remove(tempPath)
-					return RestoreInfo{}, fmt.Errorf("%s", msg)
-				}
-				if cfg.Verbose {
-					fmt.Fprintln(os.Stderr, msg)
-				}
+				fmt.Fprintf(os.Stderr, "%s: warning: failed to restore original group (%d→%d): %v\n", f.Path, curGID, origGID, chownErr)
 			}
 		}
 
 		// Attempt owner preservation: chown(origUID, -1).
 		if curUID != origUID {
 			if chownErr := os.Chown(tempPath, origUID, -1); chownErr != nil {
-				msg := fmt.Sprintf("%s: failed to restore original owner (%d→%d): %v", f.Path, curUID, origUID, chownErr)
-				if strictMode {
-					os.Remove(tempPath)
-					return RestoreInfo{}, fmt.Errorf("%s", msg)
-				}
-				if cfg.Verbose {
-					fmt.Fprintln(os.Stderr, msg)
-				}
+				fmt.Fprintf(os.Stderr, "%s: warning: failed to restore original owner (%d→%d): %v\n", f.Path, curUID, origUID, chownErr)
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

### 1. Add skipped owner mismatch to scan and shrink reports

The `SkippedOwnerMismatch` counter was already tracked in the scanner and shrink packages but never printed in the summary reports.

**Scan report** now shows:
```
skipped already offloaded:  0
skipped too young:          363
skipped owner mismatch:     X    ← NEW
skipped file not found:     2
```

**Shrink report** now shows:
```
skipped no autograph:       X
skipped owner mismatch:     X    ← NEW
skipped file not found:     X
```

### 2. Decouple restore from ownership_policy

`ownership_policy` now controls **only offload/shrink eligibility**. Restore always uses best-effort metadata preservation regardless of the policy setting.

**Before:** Under `require-daemon-owner`, a `chown` failure during restore would abort the entire restore — the file would remain sparse.

**After:** All `chown` failures during restore are logged as warnings but never block the restore. The restored file may end up owned by the daemon user if uid/gid preservation is not permitted, which is preferable to leaving the file sparse.

Fatal restore errors (unchanged):
- remote id unavailable
- credentials unavailable
- download failed
- size mismatch
- not enough disk space
- cannot chmod temp file
- cannot rename temp over target

Non-fatal restore warnings (changed from fatal under `require-daemon-owner`):
- `chown(-1, gid)` failure → warning
- `chown(uid, -1)` failure → warning
- stat temp file for ownership check failure → warning

### Files changed

- `cmd/media-offload/main.go`: Add `skipped owner mismatch` line to scan and shrink report summaries
- `pkg/restore/restore.go`: Remove `strictMode` branches; all chown/stat failures are warnings only
- `pkg/config/config.go`: Clarify `OwnershipPolicy` scope in doc comment
- `README.md`: Clarify ownership_policy controls offload eligibility only; add Restore behavior subsection

---

*This PR was created by an AI agent (OpenHands) on behalf of the repository owner.*